### PR TITLE
Flex fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ archive/
 *.[rR][dD][aA][tT][aA]
 *.[rR][dD][sS]
 *.[rR][dD][aA]
+
+# png files from checking reports # 
+*.[pP][nN][gG]

--- a/Data Quality Checks.Rmd
+++ b/Data Quality Checks.Rmd
@@ -106,6 +106,9 @@ if(iz == TRUE) {ft_geo_check <- ft_geo_check %>%  color(~ S02!=1279, ~S02, color
 ft_geo_check <- ft_geo_check %>%
   autofit()
 
+#saving flextable as image to work around pandoc issues
+save_as_image(ft_geo_check, path = "check1.png")
+
 ```  
 
 Are the expected geographies appearing for all expected years?<br>

--- a/Data Quality Checks.Rmd
+++ b/Data Quality Checks.Rmd
@@ -167,7 +167,6 @@ matched <- merge(x = new_scot, y = old_scot, by=c("code", "year")) %>%
   upci_match =ifelse((upci.x ==""|upci.y ==""),
                                   0,round((upci.x-upci.y)/upci.x,3)),
   year=as.factor(year))
-  
 
 ```
 
@@ -177,8 +176,8 @@ New rows of data (e.g. the latest year of data) cannot be compared if it wasn't 
 Sometimes figures can change, maybe the SMR records are more complete or new references files like the postcode lookup have been used which make small differences. <br>
 Use your judgement to decide if any differences are acceptable.
 
-```{r, echo=FALSE}
-flextable(matched,
+```{r,out.width = "800px", echo=FALSE}
+ft_check3 <- flextable(matched,
   col_keys = c("code", "areaname","year","numerator.x", "numerator.y","numerator_match",
                "rate.x", "rate.y","rate_match",
                "lowci.x","lowci.y", "lowci_match",
@@ -196,6 +195,11 @@ flextable(matched,
   color(~ lowci_match !=0,~lowci_match, color= "red") %>% 
   color(~ upci_match !=0,~upci_match, color = "red") %>%
   autofit()
+
+#saving flextable as image to work around pandoc issues
+save_as_image(ft_check3 , path = "check3.png")
+
+knitr::include_graphics("check3.png")
 ```
 
 ------------------------------------------------------------------------------------

--- a/Data Quality Checks.Rmd
+++ b/Data Quality Checks.Rmd
@@ -118,9 +118,11 @@ If some geographies are missing consider:<br>
 Is any suppression already applied to the dataset?<br>
 Might there legitimately be no data for that area (e.g. there might have been no deaths in that intermediate zone)?
 
-```{r, echo=FALSE}
-#print flextable
-ft_geo_check 
+```{r, out.width = "400px", echo=FALSE}
+knitr::include_graphics("check1.png")
+
+#print flextable - this method of printing flextables should work when pandoc gets updated
+#ft_geo_check 
 
 ```
 


### PR DESCRIPTION
I upgraded flextable and as predicted the tables stopped working becuase of the version of pandoc on the server.  I found a work around on the Team channel which involves converting the table into an image and then rendering the image.  Its a bit of a hack and i had to set the size of the tables which might not be ideal but I think it should work and was pretty quick to implement.