### PR TITLE
ER: Separating SIMD data out of popgroup files

### DIFF
--- a/2.deprivation_analysis.R
+++ b/2.deprivation_analysis.R
@@ -411,7 +411,8 @@ data_depr_totals <- data_depr_totals %>% summarise_all(sum, na.rm = T) %>%
 
   #Saving file
   saveRDS(data_shiny, file = paste0(data_folder, "Data to be checked/", filename, "_ineq.rds"))
-
+  saveRDS(data_shiny, file = paste0(data_folder, "Test Shiny Data/", filename, "_ineq.rds"))
+  
   #Making final dataset available outside the function
   final_result <<- data_shiny
   
@@ -647,11 +648,16 @@ analyze_deprivation_aggregated <- function(filename, # the prepared data, withou
   
   if (qa == FALSE) { #if you don't want to run full data quality checks set qa=false then only scotland chart will be produced
     #Selecting Health boards and Scotland for latest year in dataset
-    ggplot(data=(data_shiny %>% subset((substr(code, 1, 3)=="S08" | code=="S00000001") 
+    qa_plot <- ggplot(data=(data_shiny %>% subset((substr(code, 1, 3)=="S08" | code=="S00000001") 
                                        & year==max(year) & quintile == "Total" & quint_type == "sc_quin")), 
-           aes(code, rate) ) +
-      geom_point(stat = "identity") +
-      geom_errorbar(aes(ymax=upci, ymin=lowci), width=0.5)
+                      aes(code, rate) ) +
+      geom_point(stat = "identity") 
+    
+    if (is.numeric(data_shiny$lowci)) {
+      qa_plot <- qa_plot +
+        geom_errorbar(aes(ymax=upci, ymin=lowci), width=0.5)
+    }
+    qa_plot
     
   } else  { # if qa set to true (default behaviour) then inequalities rmd report will run
     

--- a/Annual Participation Measure.R
+++ b/Annual Participation Measure.R
@@ -1,3 +1,6 @@
+## N.B. THIS MEASURE ALSO IN THE NPF DATA READ IN IN THE NPF SCRIPT. COULD DO ALL PROCESSING THERE IF COVERAGE IS THE SAME.
+###############################################################################################################################
+
 ### analyst notes ----
 
 # this script produces data for the following indicator:- 13053- Annual participation (in education, training or employment) measure for 16 – 19 year olds

--- a/National Performance Framework.R
+++ b/National Performance Framework.R
@@ -12,9 +12,23 @@
 
 # Data source is the National Performance Framework open data on statistics.gov.scot
 # 2024 update: https://statistics.gov.scot/downloads/file?id=ca23e4da-4aa2-49e7-96e2-38f227f9d0de%2FALL+NPF+INDICATORS+-+2024+-+statistics.gov.scot+NPF+database+excel+file+-+August+2024.xlsx
+# (N.B. THERE ARE OTHER SCOTPHO INDICATORS IN THIS FILE THAT COULD BE USED TO DE-DUPLICATE OTHER SCRIPTS. NOT READ IN CURRENTLY.)
 
 ### functions/packages ----
 source("1.indicator_analysis.R") 
+source("2.deprivation_analysis.R") 
+
+### Lookups
+
+# bring in LA dictionary and include LA codes
+la_lookup <- readRDS(paste0(lookups, "Geography/CAdictionary.rds"))%>%
+  mutate(geographylevel="Local Authority")
+hb_lookup <- readRDS(paste0(lookups, "Geography/HBdictionary.rds"))%>%
+  mutate(geographylevel="Health Board")
+
+area_lookup <-rbind(la_lookup,hb_lookup)
+
+rm(hb_lookup,la_lookup)
 
 
 ### 1 - Read in data -----
@@ -40,112 +54,157 @@ data <- dat %>%
   # Clean column names
   clean_names() %>% 
   
-  # Select relevant indicators
-  filter(indicator %in% c("Persistent poverty", # capitalisation change in 2024 data?
+  # Select relevant indicators 
+  filter(indicator %in% c("Persistent poverty", 
                           "Child Wellbeing and Happiness", #NPF name for young peoples mental wellbeing indicator
-                          "Child material deprivation",
-                          "Children's material deprivation",
+                          "Child material deprivation", "Children's material deprivation",
+                          "Contractually secure work",
                           "Health risk behaviours",
-                          "Gender balance in organisations")) %>%
+                          "Gender balance in organisations",
+                          "Access to green and blue space",
+                          "Healthy Start", #perinatal mort
+                          "Employees on the Living wage", "Employees on the living wage",
+                          "Places to interact",
+                          "Satisfaction with housing", "Satisfaction with Housing",
+                          "Quality of public services",
+                          "Visits to the outdoors", "Visits to the Outdoors",
+                          "Work place learning"
+                        # Other ScotPHO/CWB indicators that could be read in from this file:
+                          # "Educational attainment 7", # school leaver attainment (other educ attainment vars too)
+                          # "Child social and physical development",
+                          # "Food Insecurity",
+                          # "Healthy life expectancy - Female",                         
+                          # "Healthy life expectancy - Male",
+                          # "Healthy life expectancy: Females",                         
+                          # "Healthy life expectancy: Males",
+                          # "Healthy weight - Adult",
+                          # "Influence over local decisions", "Loneliness", "Mental wellbeing", "Pay gap", 
+                          # "Perceptions of local area", "Physical activity", "Premature mortality", "Unmanageable debt", "Young peoples participation"
+                      )) %>%
+  filter(!(indicator=="Child Wellbeing and Happiness" & substr(disaggregation, 1, 18)!="Total Difficulties")) %>% # remove the SDQ subsection data, keep only Total Diffs
+  
+  # Convert indicator names to lower case and add underscore 
+  mutate(indicator = str_replace_all(tolower(indicator), " ", "_"),
+         indicator = str_replace_all(indicator, "children's", "child")) %>% #standardise these two indicators
+
+  # Standardise/simplify disaggregation names
   
   # Persistent poverty has splits labelled the wrong way round in 2024 data: reverse these
-  mutate(temp_breakdown = ifelse(indicator=="Persistent poverty", disaggregation, breakdown),
-         temp_disagg = ifelse(indicator=="Persistent poverty", breakdown, disaggregation)) %>%
+  mutate(temp_breakdown = ifelse(indicator=="persistent_poverty", disaggregation, breakdown),
+         temp_disagg = ifelse(indicator=="persistent_poverty", breakdown, disaggregation)) %>%
   
   select(-c(breakdown, disaggregation)) %>%
   
-  rename(breakdown = temp_breakdown,
-         disaggregation = temp_disagg) %>%
+  rename(split_value = temp_breakdown,
+         split_name = temp_disagg) %>%
 
+  # Sort the splits for child wellbeing and happiness
+  mutate(split_name = gsub("Total Difficulties Score", "Total", split_name)) %>%
+  mutate(split_name = gsub("Total X ", "", split_name)) %>%
+  
+  # Sort for satisfaction with housing (add note in tech doc that the splits refer to the highest income householder)
+  mutate(split_name = gsub(" of the highest income householder", "", split_name)) %>%
+  
+  # standardise other splits:
+  mutate(split_name = case_when(split_name %in% c("Six fold urban-rural 2020 classification", "Two fold urban-rural 2020 classification",
+                                                          "Urban Rural  Classification 6-fold", "Urban Rural classification") ~ "Urban/Rural", TRUE ~ split_name)) %>%
+  mutate(split_name = case_when(split_name %in% c("Scottish Index of Multiple Deprivation", "SIMD") ~ "Deprivation (SIMD)", TRUE ~ split_name)) %>%
+  mutate(split_name = ifelse(split_name == "Equivalised Income", "Income (equivalised)", split_name)) %>%
+  mutate(split_name = ifelse(split_name == "Household tenure", "Tenure", split_name)) %>%
+  mutate(split_name = ifelse(split_name == "Self-perception of health", "Self-assessed health", split_name)) %>%
+  mutate(split_name = ifelse(split_name == "Declared limiting long term physical or mental health condition", "Limiting long term physical or mental health condition", split_name)) %>%
+  mutate(split_name = ifelse(split_name == "Local authority", "Local Authority", split_name)) %>%
+  mutate(split_name = ifelse(split_name == "Employees on less than the Living wage", "Total", split_name)) %>%
+  mutate(split_name = ifelse(split_name == "NHS Board", "Health Board", split_name)) %>%
+  
+  
+  # Standardise/simplify breakdown names
 
-         # Convert indicator names to lower case and hyphenate 
-  mutate(indicator = str_replace_all(tolower(indicator), " ", "_"),
-         
-         indicator = str_replace_all(indicator, "children's", "child"),
-         
-         # Ensure age breakdowns are named consistently
-         breakdown = str_replace_all(breakdown, "Age ", ""),
-         breakdown = str_replace_all(breakdown, "-", " to "),
+  # Age breakdowns 
+  mutate(split_value = str_replace_all(split_value, "Age ", ""),
+         split_value = str_replace_all(split_value, "-", " to "),
          # Add hyphen back in where needed:
-         breakdown = if_else(breakdown == "Non to Limiting Longstanding Illness", "Non-Limiting Longstanding Illness", breakdown),
-         breakdown = if_else(breakdown == "Working to age adults", "Working-age adults", breakdown),
-         
-         
-         # Ensure SIMD breakdowns are named consistently
-         breakdown = str_replace_all(breakdown, "SIMD ", ""),
-         breakdown = if_else(str_detect(breakdown, "$1$|1st|(?i)most"), "1 - most deprived", breakdown),
-         breakdown = if_else(str_detect(breakdown, "$2$|2nd"), "2", breakdown),
-         breakdown = if_else(str_detect(breakdown, "$3$|3rd"), "3", breakdown),
-         breakdown = if_else(str_detect(breakdown, "$4$|4th"), "4", breakdown),
-         breakdown = if_else(str_detect(breakdown, "$5$|5th|(?i)least"), "5 - least deprived", breakdown),
-         
-         breakdown = str_replace_all(breakdown, "Total", "All"), # this series used in pop group data file
-         
-         # Remove characters from year column
-         year = if_else(str_detect(year, "(excl. 2020)"), "2017-2021", year),
-         
-         # Add indicator ids
-         ind_id = case_when(indicator == "persistent_poverty" ~ 99116,
+         split_value = if_else(split_value == "Non to Limiting Longstanding Illness", "Non-Limiting Longstanding Illness", split_value),
+         split_value = if_else(split_value == "Working to age adults", "Working-age adults", split_value)) %>% 
+  
+  # SIMD breakdowns 
+  mutate(split_value = str_replace_all(split_value, "Quintile ", ""),
+         split_value = if_else(str_detect(split_value, "^1$|1st|(?i)most"), "1", split_value), # regexp looks for single number, or "1st", or "most" (ignoring case)
+         split_value = if_else(str_detect(split_value, "^2$|2nd"), "2", split_value),
+         split_value = if_else(str_detect(split_value, "^3$|3rd"), "3", split_value),
+         split_value = if_else(str_detect(split_value, "^4$|4th"), "4", split_value),
+         split_value = if_else(str_detect(split_value, "^5$|5th|(?i)least"), "5", split_value)) %>%
+  
+  # Income splits
+  mutate(split_value = case_when(split_value=="Bottom Quintile" ~ "1 - lowest income",
+                               split_value=="Top Quintile" ~ "5 - highest income",
+                               TRUE ~ split_value)) %>%
+  # Gender
+  mutate(split_value = case_when(split_value %in% c("Men", "Man") ~ "Men",
+                                 split_value %in% c("Women", "Woman") ~ "Women",
+                                 split_value %in% c("Males", "Male") ~ "Male",
+                                 split_value %in% c("Females", "Female") ~ "Female",
+                                 TRUE ~ split_value)) %>%
+  
+  # Formats
+  mutate(split_value = gsub("  ", " ", split_value)) %>% # remove double spaces
+  
+  # Totals
+  mutate(split_value = str_replace_all(split_value, "All", "Total")) %>% # this series used in pop group data file (both are found in there actually)
+ 
+  
+  # Add indicator ids
+  mutate(ind_id = case_when(indicator == "persistent_poverty" ~ 99116,
                             indicator == "child_wellbeing_and_happiness" ~ 99117,
                             indicator == "child_material_deprivation" ~ 99118,
                             indicator == "health_risk_behaviours" ~ 99121,
-                            indicator == "gender_balance_in_organisations" ~ 99123),
+                            indicator == "gender_balance_in_organisations" ~ 99123#,
+                            # These indicators need IDs, and adding to techdoc:
+                            # indicator == "contractually_secure_work" ~ xxxxx,
+                            # indicator == "access_to_green_and_blue_space" ~ xxxxx,
+                            # indicator == "healthy_start" ~ xxxxx,
+                            # indicator == "employees_on_the_living_wage" ~ xxxxx, 
+                            # indicator == "places_to_interact" ~ xxxxx,
+                            # indicator == "satisfaction_with_housing" ~ xxxxx, 
+                            # indicator == "quality_of_public_services" ~ xxxxx,
+                            # indicator == "visits_to_the_outdoors" ~ xxxxx, 
+                            # indicator == "work_place_learning" ~ xxxxx
+                            )) %>%
          
-         # Create date variables
-         trend_axis = year,
-         year = case_when(indicator %in% c("health_risk_behaviours", "gender_balance_in_organisations") ~ as.numeric(year),
-                          !indicator %in% c("health_risk_behaviours", "gender_balance_in_organisations") ~ as.numeric(str_sub(trend_axis, start= 1, end = 4))+2),
-         def_period = case_when(indicator == "persistent_poverty" ~ paste0("5-year aggregate (",trend_axis,")"),
-                                indicator == "child_wellbeing_and_happiness" ~ paste0("4-year aggregate (",trend_axis,")"),
-                                indicator == "child_material_deprivation" ~ paste0("4-year aggregate (",trend_axis,")"),
-                                indicator == "health_risk_behaviours" ~ paste0(year, " survey year"),
-                                indicator == "gender_balance_in_organisations" ~ paste0(year, " calendar year")),
-         
-         # Create some other new variables
-         numerator = NA, 
-         lowci = NA, upci = NA,
-         rate = as.numeric(figure),
-         code = "S00000001") %>%
+  # Create date variables (N.B. revisit the logic if more indicators added: available periods may change)
+  mutate(trend_axis = case_when(nchar(year)==4 ~ year, # keep as is if single years
+                                # expand the ranges to show full years (some do but some don't)       
+                                nchar(year)>4 ~ paste0(substr(year, 1, 4), "-", as.character(2000+as.numeric(substr(year, nchar(year)-1, nchar(year))))), 
+                                TRUE ~ NA)) %>%
+  mutate(year = case_when(nchar(year)==4 ~ as.numeric(year),
+                          nchar(year)>4 ~ as.numeric(substr(year, 1, 4)) + 2)) %>% # add 2 to the start year of 4- and 5-year ranges as an approximate midpoint for plotting
+  mutate(def_period = case_when(indicator == "healthy_start" ~ paste0(year, " calendar year"),
+                                nchar(trend_axis)==4 ~ paste0(year, " survey year"),
+                                as.numeric(substr(trend_axis, 8, 9)) - as.numeric(substr(trend_axis, 3, 4)) == 3 ~ paste0("4-year aggregate (",trend_axis,")"),
+                                as.numeric(substr(trend_axis, 8, 9)) - as.numeric(substr(trend_axis, 3, 4)) == 4 ~ paste0("5-year aggregate (",trend_axis,")"))) %>%
+
+  # Add geography codes
+  mutate(geographylevel = case_when(split_name %in% c("Local Authority", "Health Board") ~ split_name,
+                                    TRUE ~ "Scotland")) %>%
+  mutate(areaname = case_when(split_name %in% c("Local Authority", "Health Board") ~ split_value,
+                              TRUE ~ "Scotland")) %>%  #3041
+  filter(!(split_name=="Local Authority" & split_value=="Scotland")) %>% #Scotland data included in the LA split
+  mutate(areaname = gsub("&", "and", areaname)) %>%
+  mutate(areaname = ifelse(areaname%in% c("Edinburgh, City of", "Edinburgh,City of"), "City of Edinburgh", areaname)) %>%
+  mutate(areaname = ifelse(areaname%in% c("Na h to Eileanan Siar", "Na to h Eileanan Siar"), "Na h-Eileanan Siar", areaname)) %>%
+  mutate(areaname = ifelse(areaname== "Aberdeen city", "Aberdeen City", areaname)) %>%
+  mutate(areaname = case_when(geographylevel=="Health Board" ~ paste("NHS", areaname),
+                              TRUE ~ areaname)) %>%
+  left_join(area_lookup, by=c("geographylevel","areaname")) %>%
+  mutate(code = ifelse(areaname=="Scotland", "S00000001", code)) %>%
   
-  # Rename columns
-  rename(split_name = disaggregation,
-         split_value = breakdown) %>% 
+  # Create other variables required
+  mutate(numerator = NA, 
+         lowci = NA, upci = NA) %>%
+  mutate(rate = round(figure, 1)) %>% # some irritating duplicates due to inconsistent rounding
   
-  # Select breakdowns of interest
-  filter(split_name %in% c("Total",
-                           "Age",
-                           "Scottish Index of Multiple Deprivation",
-                           "SIMD",
-                           "Local Authority",
-                           "HSC partnership",
-                           "Health board",
-                           "Gender",
-                           "Sex",
-                           "Disability", #gender balance
-                           "Ethnicity", #gender balance
-                           "Urban Rural classification",
-                           "Total Difficulties Score",  
-                           "Total Difficulties Score X Sex",
-                           "Total Difficulties Score X Age",
-                           "Total Difficulties Score X SIMD",
-                           "Total Difficulties Score X Equivalised Income",
-                           "Total Difficulties Score X Limiting Longstanding Illness",
-                           	"Disability of household member(s)" # child mat deprivation
-                           )) %>% 
-  
-  # Further tidy breakdown names
-  mutate(split_name = str_replace_all(split_name, "Total Difficulties Score X ", ""),
-         split_name = str_replace_all(split_name, "Total Difficulties Score", "Total"),
-         split_name = case_when(split_name=="Equivalised Income" ~ "Income (equivalised)",
-                                split_name=="SIMD" ~"Deprivation (SIMD)",
-                                split_name=="Scottish Index of Multiple Deprivation"~"Deprivation (SIMD)",
-                                split_name=="Urban Rural classification" ~"Urban/Rural",
-                                TRUE ~ split_name)) %>%
-  
-  # Ensure equivalised income quintiles are named consistently
-  mutate(split_value = case_when(split_value=="Top Quintile" ~ "1 - highest income",
-                                 split_value=="Bottom Quintile" ~ "5 - lowest income", 
-                                 TRUE ~ split_value)) %>%
+  # # Select breakdowns of interest
+  # filter(split_name %in% c(       )) %>% # Any to be removed?
   
   # Select relevant variables
   select(c(ind_id, indicator, code, split_name, split_value, year, trend_axis, def_period, rate, numerator, lowci, upci)) %>%
@@ -154,123 +213,117 @@ data <- dat %>%
   mutate(indicator = case_when (indicator=="child_wellbeing_and_happiness" ~ "young_peoples_mental_wellbeing", TRUE ~indicator)) %>%
   
   # Reorder data frame
-  arrange(indicator, code, year)
+  arrange(indicator, code, year) %>%
+  distinct() # get rid of duplicates n=2979 now
   
+# Make sure each non-geographic split-name has a Total split_value rate:
 
+# get the totals 
+totals <- data %>% 
+  filter(split_value == "Total") %>% 
+  filter(!(indicator %in% c("persistent_poverty", "contractually_secure_work") & split_name!="Age")) %>% # keep only Age split for these two, as some of their other 'Total' data differs, bizarrely
+  select(c(ind_id, indicator, code, split_value, year, trend_axis, def_period, rate, numerator, lowci, upci)) %>%
+  distinct() # n=168
+
+# which rows require totals to be added in?
+data_totals <- data %>%
+  filter(split_name!="Total") %>% # drop all the totals
+  filter(split_value!="Total") %>%
+  filter(code=="S00000001") %>% # exclude CA and HB data (to be separated out into main data, with no splits available. Their 'total' is the Scotland-level data)
+  select(ind_id, indicator, code, split_name, year, trend_axis, def_period) %>%
+  distinct()  %>%
+  merge(y=totals, by=c("ind_id", "indicator", "code", "year", "trend_axis", "def_period")) # still n=629
+
+# get original rows for splits without totals
+data_no_totals <- data %>% 
+  filter(split_name!="Total") %>%
+  filter(split_value!="Total") %>% 
+  distinct() #2559 obs
+
+# get original rows for Scotland
+scot_data <- data %>% 
+  filter(split_name=="Total") %>% 
+  distinct() #162
+
+# combine these:
+data_with_totals <- rbind(scot_data, data_no_totals, data_totals) %>% # 3350
+  arrange(readr::parse_number(split_value)) # sorts the age groups into the right order
+
+  
 
 ### 3. Prepare final files -----
 
 # Function to prepare final files:
-# Creates two data files for each indicator (main data vs population group data)
+# Creates three data files for each indicator (main, popgroup, and deprivation data)
 prepare_final_files <- function(ind){
-   
-  #Save total rows (to later add back in to pop groups data)
-  total <- data %>% 
-    filter(indicator == ind,
-           split_value == "All") # uses split_value instead of split_name as persistent poverty doesn't have "total" in split_name
   
+  df <- data_with_totals %>%
+    filter(indicator==ind)
+
+  
+     
   # 1 - Main data 
   # (ie dataset behind scotland and/or sub national summary data that populates summary/trend/rank tab)
-  maindata <- total %>%
-    select(code, ind_id, year,numerator,rate,lowci,upci,def_period, trend_axis) %>% #select fields required for maindata file (ie summary/trend/rank tab)
-    unique()
   
+  maindata <- df %>%
+    filter(split_name %in% c("Total", "Health Board", "Local Authority")) %>%
+    select(code, ind_id, year, numerator, rate, lowci, upci, def_period, trend_axis)  #select fields required for maindata file (ie summary/trend/rank tab)
 
+  # Save files
+  write_rds(maindata, paste0(data_folder, "Data to be checked/", ind, "_shiny.rds"))
+  write.csv(maindata, paste0(data_folder, "Data to be checked/", ind, "_shiny.csv"), row.names = FALSE)
+  
+  write_rds(maindata, paste0(data_folder, "Test Shiny Data/", ind, "_shiny.rds"))
+  write.csv(maindata, paste0(data_folder, "Test Shiny Data/", ind, "_shiny.csv"), row.names = FALSE)
+  
+  # Make data created available outside of function so it can be visually inspected if required
+  maindata_result <<- maindata
+
+  
+    
   # 2 - Population group data 
   # (ie data behind population groups tab)
 
+  pop_grp_data <- df %>%
+    filter(!split_name %in% c("Total", "Health Board", "Local Authority", "Deprivation (SIMD)")) %>%
+    select(code, ind_id, split_name, split_value, year, numerator, rate, lowci, upci, def_period, trend_axis) 
 
-  # Young people's mental wellbeing
-  # Add additional total rows (to show an "all" category) for age, sex and LLI breakdowns
-  if(ind == "young_peoples_mental_wellbeing"){
-    
-    #need to run horrible fix to ensure age groups sort in the correct order
-    #select only the data that contains age group split and mutate values to desired sort order
-    pop_grp_data_age <- data %>%
-      filter(indicator == ind) %>%
-      mutate(split_name = str_replace_all(split_name, "Total", "Age")) |>
-            filter(split_name =="Age") |>
-      mutate(split_value = case_when(split_value == "4 to 6" ~ "a_4 to 6", 
-                                     split_value == "7 to 9" ~ "b_7 to 9",
-                                     split_value == "10 to 12" ~ "c_10 to 12",
-                                     split_value == "All" ~ "z_All",
-                                     TRUE ~ split_value)) %>%
-      arrange(ind_id,code,year,split_name, split_value) |>
-      mutate(split_value = trimws(substr(split_value,3,11))) #trim white space and remove sort precursor to return split value to sensible string
-    
-    
-    pop_grp_data  <- data |>
-      filter(indicator == ind) %>%
-      filter(split_name !="Age") %>% #remove the age split data (this group will be added back in next line with data sorted correctly)
-      arrange(ind_id,code,year,split_name, split_value) %>%
-      mutate(split_name = str_replace_all(split_name, "Total", "Sex")) %>% 
-      bind_rows(total) %>% 
-      mutate(split_name = str_replace_all(split_name, "Total", "Limiting Longstanding Illness")) %>% 
-      bind_rows(total) %>% 
-      mutate(split_name = str_replace_all(split_name, "Total", "Deprivation (SIMD)")) %>%
-      bind_rows(total) %>% 
-      mutate(split_name = str_replace_all(split_name, "Total", "Income (equivalised)")) %>% 
-      bind_rows(pop_grp_data_age)
+  # Save files
+  write_rds(pop_grp_data, paste0(data_folder, "Data to be checked/", ind, "_shiny_popgrp.rds"))
+  write.csv(pop_grp_data, paste0(data_folder, "Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
 
-    # Child material deprivation
-    # Add additional total rows (to show an "all" category) for age and disability breakdowns
-  } else if(ind == "child_material_deprivation"){
-    
-    pop_grp_data <- data %>%
-      filter(indicator == ind) %>% 
-      mutate(split_name = str_replace_all(split_name, "Total", "Age")) %>% 
-      bind_rows(total) %>% 
-      mutate(split_name = str_replace_all(split_name, "Total", "Disability of household member(s)"))
-    
-    # Health risk behaviours
-    # Add additional total rows (to show an "all" category) for age, gender, disability and urban/rural breakdowns
-  } else if(ind == "health_risk_behaviours"){
-    
-    pop_grp_data <- data %>%
-      filter(indicator == "health_risk_behaviours") %>% 
-      mutate(split_name = str_replace_all(split_name, "Total", "Age")) %>% 
-      filter(!split_value == "All" | !year %in% c(2012, 2013, 2014, 2016, 2021)) %>% # Removes total rows for years with no age breakdowns
-      bind_rows(total %>% filter(year %in% c(2016, 2017, 2018, 2019))) %>%  # Only bind new rows of total data for years with gender breakdowns
-      mutate(split_name = str_replace_all(split_name, "Total", "Gender")) %>% 
-      bind_rows(total %>% filter(year %in% c(2016, 2017, 2018, 2019))) %>%  # Only bind new rows of total data for years with gender breakdowns
-      mutate(split_name = str_replace_all(split_name, "Total", "Deprivation (SIMD)")) %>% 
-      bind_rows(total %>% filter(year %in% c(2017, 2018, 2019))) %>%  # Only bind new rows of total data for years with disability breakdowns
-      mutate(split_name = str_replace_all(split_name, "Total", "Disability"))  %>% 
-      bind_rows(total %>% filter(year %in% c(2017, 2018, 2019))) %>%  # Only bind new rows of total data for years with urban/rural breakdowns
-      mutate(split_name = str_replace_all(split_name, "Total", "Urban/Rural"))
-    
-    # Gender balance in organisations
-    # Already have "all" categories for each breakdown
-    # Remove "total" from split_name so it doesn't show as a breakdown
-  } else if(ind == "gender_balance_in_organisations"){
-    
-    pop_grp_data <- data %>%
-      filter(indicator == ind,
-             split_name != "Total") 
-    
-    # Persistent poverty
-    # Already includes "all" category for age breakdown and no "total" under split name to remove
-  } else {
-    
-    pop_grp_data <- data %>%
-      filter(indicator == ind) 
-  }
-   
-    pop_grp_data <- pop_grp_data %>%
-    select(ind_id, code, year, numerator,rate,lowci,upci,def_period, trend_axis, split_name, split_value) #select fields required for popgroup data file (linked to pop group tab)
-   
-    # Save files in folder to be checked
-    write.csv(maindata, paste0(data_folder, "Data to be checked/", ind, "_shiny.csv"), row.names = FALSE)
-    write_rds(maindata, paste0(data_folder, "Data to be checked/", ind, "_shiny.rds")) 
-    
-    write.csv(pop_grp_data, paste0(data_folder,  "Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
-    write_rds(pop_grp_data, paste0(data_folder,  "Data to be checked/", ind, "_shiny_popgrp.rds"))
-    
+  write_rds(pop_grp_data, paste0(data_folder, "Test Shiny Data/", ind, "_shiny_popgrp.rds"))
+  write.csv(pop_grp_data, paste0(data_folder, "Test Shiny Data/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
   
-    # Make data created available outside of function so it can be visually inspected if required
-    maindata_result <<- maindata
-    popgrpdata_result <<- pop_grp_data
-    
+  # Make data created available outside of function so it can be visually inspected if required
+  pop_grp_data_result <<- pop_grp_data
+  
+  
+  
+  # 3 - Deprivation data
+  # National level only 
+  if("Deprivation (SIMD)" %in% unique(df$split_name)) {
+    simd1 <- df %>%
+      filter(split_name == "Deprivation (SIMD)") %>%
+      rename(quintile = split_value) %>%
+      mutate(quint_type="sc_quin") %>%
+      select(-split_name, -indicator)
+  
+  # Save intermediate SIMD file
+  write_rds(simd1, file = paste0(data_folder, "Prepared Data/", ind, "_shiny_depr_raw.rds"))
+  write.csv(simd1, file = paste0(data_folder, "Prepared Data/", ind, "_shiny_depr_raw.csv"), row.names = FALSE)
+  
+  #get ind_id argument for the analysis function 
+  ind_id <- unique(simd1$ind_id)
+  
+  # Run the deprivation analysis (saves the processed file to 'Data to be checked')
+  analyze_deprivation_aggregated(filename = paste0(ind, "_shiny_depr"), 
+                                 pop = "depr_pop_16+", # these are adult (16+) indicators, with no sex split for SIMD
+                                 ind_id, 
+                                 ind)
+  
+  }
+  
 }
 
 
@@ -279,7 +332,6 @@ prepare_final_files <- function(ind){
 # Indicator 99116: Persistent poverty ----
 prepare_final_files(ind = "persistent_poverty")
 
-#run_qa(filename = "persistent_poverty") #come back to fix qa report - failing because no NHS board or ca geographies ins some of these indcators
 
 # Indicator 99117: Young peoples mental wellbeing  ----
 prepare_final_files(ind = "young_peoples_mental_wellbeing")


### PR DESCRIPTION
Previous inconsistency: some SIMD data presented on popgroup tab (without additional metrics) and some presented on Deprivation tab. This PR fixes this, by amending the NPF and Healthy life expectancy processing, to split the popgroups file into non-SIMD data and SIMD data, with the latter then being processed to give the inequals metrics for the deprivation tab. All files produced (maindata, popgroup, and ineq) are in Test Shiny Data now, with any previous files moved from Shiny Data to Shiny Data/Archive so that the data prep functions can be run. I've run these successfully and checked that the deprivation and pop groups tabs now display the right splits. There are now no SIMD data being presented on the popgroups tab. The indicator 'gender balance in organisations' has some negative %, which display OK on some popgroup and deprivation charts but not others. Looks like the 'attributable to inequality' chart has most problems with this.

N.B. There are an additional 8 CWB indicators that could be extracted from the NPF data. These are identified in the NPF script, but not processed for the app yet. They need ind_ids and the techdoc needs to be updated for them. This should be a quick win for increasing the number of indicators in the CWB profile.  