### PR TITLE
update with 2021/22 data

### DIFF
--- a/Child healthy weight.R
+++ b/Child healthy weight.R
@@ -7,13 +7,13 @@
 ## Packages/Filepaths/Functions ----
 ###############################################.
 source("1.indicator_analysis.R") #Normal indicator functions
-source("2.deprivation_analysis.R") # deprivation function
+#source("2.deprivation_analysis.R") # deprivation function
 
 ###############################################.
 ## Part 1 - Prepare basefile ----
 ###############################################.
 # Reading data provided by child health team for datazones 2011
-child_weight11 <- read.spss( paste0(data_folder, "Received Data/IR2022-00007_DZ2011-child-weight.sav"), 
+child_weight11 <- read.spss(paste0(data_folder, "Received Data/Child Healthy Weight/old data/IR2023-00039- child weight/IR2023-00039_DZ2011.sav"), 
                           to.data.frame=TRUE, use.value.labels=FALSE) %>% 
   setNames(tolower(names(.))) %>% #variable names to lower case
   rename(datazone = datazone2011, numerator = healthy_weight, denominator = tot) %>% 
@@ -25,31 +25,31 @@ child_weight11 <- read.spss( paste0(data_folder, "Received Data/IR2022-00007_DZ2
 
 saveRDS(child_weight11, file=paste0(data_folder, 'Prepared Data/child_healthyweight_raw.rds'))
 
-###############################################.
-# Datazone2001 
-child_weight01 <- read.spss( paste0(data_folder, "Received Data/IR2022-00007_DZ2001-child-weight.sav"), 
-                             to.data.frame=TRUE, use.value.labels=FALSE)%>% 
-  setNames(tolower(names(.))) %>%  #variable names to lower case
-  rename(datazone = datazone2001, numerator = healthy_weight, denominator = tot) %>% 
-  # reformat the year variable.
-  mutate(year = as.numeric(paste0("20", substr(schlyr_exam, 1, 2)))) %>% 
-  # aggregate to get the count
-  group_by(year, datazone) %>% 
-  summarise_at(c("numerator", "denominator"), list(sum), na.rm =T) %>%  ungroup()
-
-###############################################.
-#Deprivation basefile
-# DZ 2001 data needed up to 2013 to enable matching to advised SIMD
-child_weight_dep <- rbind(child_weight01 %>% subset(year<=2013), 
-                          child_weight11 %>% subset(year>=2014)) 
-
-saveRDS(child_weight_dep, file=paste0(data_folder, 'Prepared Data/child_healthyweight_depr_raw.rds'))
+# ###############################################.
+# # Datazone2001 
+# child_weight01 <- read.spss( paste0(data_folder, "Received Data/IR2022-00007_DZ2001-child-weight.sav"), 
+#                              to.data.frame=TRUE, use.value.labels=FALSE)%>% 
+#   setNames(tolower(names(.))) %>%  #variable names to lower case
+#   rename(datazone = datazone2001, numerator = healthy_weight, denominator = tot) %>% 
+#   # reformat the year variable.
+#   mutate(year = as.numeric(paste0("20", substr(schlyr_exam, 1, 2)))) %>% 
+#   # aggregate to get the count
+#   group_by(year, datazone) %>% 
+#   summarise_at(c("numerator", "denominator"), list(sum), na.rm =T) %>%  ungroup()
+# 
+# ###############################################.
+# #Deprivation basefile
+# # DZ 2001 data needed up to 2013 to enable matching to advised SIMD
+# child_weight_dep <- rbind(child_weight01 %>% subset(year<=2013), 
+#                           child_weight11 %>% subset(year>=2014)) 
+# 
+# saveRDS(child_weight_dep, file=paste0(data_folder, 'Prepared Data/child_healthyweight_depr_raw.rds'))
 
 ###############################################.
 ## Part 2 - Run analysis functions ----
 ###############################################.
 analyze_first(filename = "child_healthyweight", geography = "datazone11", 
-              measure = "percent", yearstart = 2002, yearend = 2020, time_agg = 1)
+              measure = "percent", yearstart = 2002, yearend = 2021, time_agg = 1)
 
 # There are several boards and councils for which we only have incomplete data 
 # for certain years as they join to the CHSPS later on.

--- a/Child healthy weight.R
+++ b/Child healthy weight.R
@@ -68,6 +68,8 @@ saveRDS(child_formatted, file=paste0(data_folder, "Temporary/child_healthyweight
 analyze_second(filename = "child_healthyweight", measure = "perc_pcf", time_agg = 1,
                pop="DZ11_pop_5", ind_id = 21106, year_type = "financial")
 
+
+
 # Excluding data for boards, hscps, las, localities and izs with incomplete data
 # Merging final data with parent geographies lookup and then filtering
 geo_parents <- readRDS(paste0(lookups, "Geography/IZtoPartnership_parent_lookup.rds")) %>% 
@@ -79,6 +81,8 @@ geo_parents <- readRDS(paste0(lookups, "Geography/IZtoPartnership_parent_lookup.
 
 data_shiny <- left_join(readRDS(file = paste0(data_folder, "Data to be checked/child_healthyweight_shiny.rds")),
                         geo_parents, by = "code") %>%
+  #negate subset (i.e. select where the following conditions are not met)
+  # local authority or council area is moray, aberdeen, aberdeenshire, or the parent area one of these & the year is less than 2009 
   subset(!(((code %in% c('S37000001', 'S37000002', "S12000033", "S12000034", 'S12000020',
                          'S37000019', 'S08000020') | # Moray, Aberdeen, Aberdeenshire
                parent_area %in% c('S37000001', 'S37000002', 'S37000019')) & year <2009) |
@@ -103,6 +107,9 @@ data_shiny <- left_join(readRDS(file = paste0(data_folder, "Data to be checked/c
 
 saveRDS(data_shiny, file = paste0(data_folder, "Data to be checked/child_healthyweight_shiny.rds"))
 write_csv(data_shiny, path = paste0(data_folder, "Data to be checked/child_healthyweight_shiny.csv"))
+
+# This indicator script doesn't use analysis functions but indicator checking report can still be called:
+run_qa(filename="child_healthyweight")
 
 ###############################################.
 # # Deprivation analysis function 


### PR DESCRIPTION
Just updating with 2021/22 data. We do have a newer extract from earlier this year that includes 2022/23 data but only starts at 2013 for some reason when our trend goes back further than that. I've just put a request in for another extract to include 2023/24 data so I'll ask for that for the full time trend to be included in that to avoid us having to read in different files for different time periods.

Just commenting out anything deprivation related too since looks like we don't run that function for this one.