### PR TITLE
tweak process to reduce chance of errors

### DIFF
--- a/Child dental health.R
+++ b/Child dental health.R
@@ -83,11 +83,12 @@ clean_data <- function(data, starting_school_year){
 }
 
 # apply function to both datasets
+# change year to match starting school year of latest data
 p1_new <- clean_data(data = p1, starting_school_year = 2023)
 p7_new <- clean_data(data = p7, starting_school_year = 2023)
 
 
-# save temp files to use in analysis functions 
+# save clean formatted files
 # change filename to match school year of latest data
 saveRDS(p1_new, file.path(data_path, "formatted", "P1_data_formatted_2023-24.rds"))
 saveRDS(p7_new, file.path(data_path, "formatted", "P7_data_formatted_2023-24.rds"))
@@ -110,7 +111,7 @@ p1_trend <- combine_files(files = list.files(path = file.path(data_path, "format
 p7_trend <- combine_files(files = list.files(path = file.path(data_path, "formatted"), pattern = "P7", full.names = TRUE))
 
 
-## step 4 - save temp files for use in analysis functions 
+## save temp files for use in analysis functions 
 saveRDS(p1_trend, file.path(scotpho_folder, "Prepared Data", "child_dental_p1_raw.rds"))
 saveRDS(p7_trend, file.path(scotpho_folder, "Prepared Data", "child_dental_p7_raw.rds"))
 


### PR DESCRIPTION
Hi Abbie,

The dental health indicators have been re-run to include 2023/24 data. I've revised the process slightly for updating these. I've split the raw data files up into separate years, and the script will read them all in and combine them to create trend data to pass through the functions.

This  is to ensure there's no accidental issues with historic data being incorrectly being overwritten etc. I noticed there were some minor errors with 2021 and 2022 data in our profiles tool not matching the raw data we received so I'm hoping this process will remove chance of error, since I've now checked every year. It means each year the analyst just needs to focus on preparing a clean file for the latest year with confidence that previous years data is correct.

Hope this makes sense but happy to chat through further if you have any questions.

Also after our chat about what is 'perc_pcf' looks like we've finally found some indicators of that measure type...will need to get this added into new functions!