### PR TITLE
ER - change paths to QA Rmd files so they can be run from different repo

### DIFF
--- a/1.indicator_analysis.R
+++ b/1.indicator_analysis.R
@@ -611,7 +611,7 @@ analyze_second <- function(filename, measure = c("percent", "crude", "perc_pcf",
 #       of any geo type to Data Check 3 (comparing old and new figures)
 
 run_qa <- function(filename, old_file="default", check_extras=c()){
-   run("3.Data Quality Checks.Rmd")
+   run("../scotpho-indicator-production/3.Data Quality Checks.Rmd")
 }  
 
 ############################################################.

--- a/2.deprivation_analysis.R
+++ b/2.deprivation_analysis.R
@@ -443,7 +443,7 @@ data_depr_totals <- data_depr_totals %>% summarise_all(sum, na.rm = T) %>%
 # filename - required - determines which indicator_data file is used for checking
 
 run_ineq_qa <- function(filename){
-  run("4.Data Quality Checks_inequalities indicators.Rmd")
+  run("../scotpho-indicator-production/4.Data Quality Checks_inequalities indicators.Rmd")
 }  
 
 

--- a/functions/helper functions/run_main_analysis_QA.R
+++ b/functions/helper functions/run_main_analysis_QA.R
@@ -1,3 +1,3 @@
 run_main_analysis_qa <- function(filename,test_file, old_file="default", check_extras=c()){
-  run("3.Data Quality Checks.Rmd")
+  run("../scotpho-indicator-production/3.Data Quality Checks.Rmd")
 }  

--- a/functions/helper functions/run_rmarkdown_QA.R
+++ b/functions/helper functions/run_rmarkdown_QA.R
@@ -1,7 +1,7 @@
 run_qa <- function(filename, old_file="default", check_extras=c(), type = c("main", "deprivation"), test_file){
   if(type == "main"){
-  run("3.Data Quality Checks.Rmd")
+  run("../scotpho-indicator-production/3.Data Quality Checks.Rmd")
   } else {
-    run("4.Data Quality Checks_inequalities indicators.Rmd")  
+    run("../scotpho-indicator-production/4.Data Quality Checks_inequalities indicators.Rmd")  
   }
 }  


### PR DESCRIPTION
The change made (adding ../scotpho-indicator-production/) will find the Rmd file **IF** run_qa() or run_main_analysis_qa() or run_ineq_qa() are called from a project in the same folder as the scotpho-indicator-production repo. Is this OK? Is there a better way to reference these files?