### PR TITLE
ER - Updating inequals QA file to take SIMD data with optional sex column

### DIFF
--- a/4.Data Quality Checks_inequalities indicators.Rmd
+++ b/4.Data Quality Checks_inequalities indicators.Rmd
@@ -33,11 +33,25 @@ data_indicator <- readRDS(paste0(output_folder,"/", filename, "_ineq.rds")) %>%
 #Add geography code names
 data_indicator <- left_join(x=data_indicator, y=code_dictionary, by="code") %>%
 mutate(code_name=paste0(code,": ",as.character(areaname))) #add field with geography code & name
-  
+
+## Are the deprivation data grouped by sex? If so this needs to be accounted for in the QA
+sex_column <- "sex" %in% names(data_indicator) # gives TRUE or FALSE
+
+# defining a new column (sex) to be added if it's not present in the data already:
+library(tibble) # for adding a column here
+cols <- c(sex = "Total")
+data_indicator <- data_indicator  %>%
+  add_column(!!!cols[!names(cols) %in% names(.)]) # adds a sex column, and fills it with "Total" if it doesn't exist in the data
+
 #Test which optional geographies are present in dataset 
 scot <-  any(substr(data_indicator$code,1,3) =="S00")
 board <- any(substr(data_indicator$code,1,3) == "S08")
 ca <- any(substr(data_indicator$code,1,3) == "S12")
+
+# Which quintile types are present in the data?
+scot_quintiles <- "sc_quin" %in% unique(data_indicator$quint_type)
+hb_quintiles <- "hb_quin" %in% unique(data_indicator$quint_type)
+ca_quintiles <- "ca_quin" %in% unique(data_indicator$quint_type)
  
 #Read in old indicator data file from network /Shiny data folder - if one exists (new indicators won't have a historic file)
 old_indicator_filepath <- paste0(data_folder, "Shiny Data/", filename, "_ineq.rds") #create value which is file path to old file
@@ -60,7 +74,7 @@ if(file.exists(old_indicator_filepath)) {
 Indicator:  **`r filename`** <br>
 Date:  **`r format(Sys.time(), '%d %B, %Y %H:%M')`** <br>
 
-**New** indicator file:  /`r (paste0(output_folder,"/", filename, ".rds"))`<br>
+**New** indicator file:  /`r (paste0(output_folder,"/", filename, "_ineq.rds"))`<br>
 **Old** indicator file (for comparisons):  /`r (paste0(old_indicator_filepath))` <br>
 
 ------------------------------------------------------------------------------------
@@ -70,6 +84,14 @@ NHS board: `r board` <br>
 Council area: `r ca` <br>
 Scotland: `r scot` <br>
 
+**Quintile types present in indicator output file** <br>
+Scotland-wide quintiles: `r scot_quintiles` <br>
+HB quintiles: `r hb_quintiles` <br>
+CA quintiles: `r ca_quintiles` <br>
+
+**Is the indicator output file also broken down by sex?** <br>
+Answer: `r sex_column` <br>
+
 ------------------------------------------------------------------------------------
 
 ##**Data check 1:** <br>
@@ -77,17 +99,17 @@ Scotland: `r scot` <br>
 
 ```{r include=FALSE}
 #Code chunk for counting unique geographies & quintiles appear for each of the quintile types
-#Within Scotland Quintiles - all geo types (Scotland, NHS Board and local authority) should be present but not necessarily all quintiles
+#Within Scotland Quintiles - all geo types (Scotland, NHS Board and local authority) could be present but not necessarily all quintiles (e.g., Shetland, Orkney)
 # Within HB Quintiles - expect 14 nhs boards only, all quintiles (5 quintils + total=6) should be available
 # Within LA Quintiles - expect 32 la only, all quintiles should be available
 #df counts how many distinct quintiles for each geography by quint type, areaname and year - used in checks on quintiles present
 quintile_checks <- data_indicator %>%
-  group_by(quint_type, trend_axis, code, areaname, geo_type, year) %>%
+  group_by(quint_type, trend_axis, code, areaname, geo_type, year, sex) %>%
   summarise(count_q=n()) %>%
   ungroup()
 #df counts how many distinct geographies by quint type and year - used to check which geographies are present
 geo_checks <- quintile_checks %>%
-  group_by(quint_type, geo_type, trend_axis) %>%
+  group_by(quint_type, geo_type, trend_axis, sex) %>%
   summarise(count=n()) %>%
   spread(geo_type, count) %>%
   ungroup()
@@ -95,30 +117,40 @@ geo_checks <- quintile_checks %>%
 ft_sc_quin_check <- geo_checks %>%
   subset(quint_type=="sc_quin") %>%
   flextable() %>%
-  color(~ S00!=1, ~S00, color = "red") %>% # Should be 14 NHS boards
-  color(~ S08!=14, ~S08, color = "red") %>% # Should be 14 NHS boards
-  color(~ S12!=32, ~S08, color = "red") %>%# Should be 14 NHS boards
+  # this section crashes the QA if the data don't have HB/CA data:
+  # color(~ S00!=1, ~S00, color = "red") %>% # Should be 1 Scotland
+  # color(~ S08!=14, ~S08, color = "red") %>% # Should be 14 NHS boards
+  # color(~ S12!=32, ~S08, color = "red") %>%# Should be 32 councils
   autofit()
+# These commands do the same job, conditional on what geogs are in the data:
+if(scot == TRUE) {ft_sc_quin_check <- ft_sc_quin_check %>% color(~ S00!=1, ~S00, color = "red")}   #should be 1 Scotland
+if(board == TRUE) {ft_sc_quin_check <- ft_sc_quin_check %>% color(~ S08!=14, ~S08, color = "red")}    #should be 14 HBs
+if(ca == TRUE) {ft_sc_quin_check <- ft_sc_quin_check %>% color(~ S12!=32, ~S12, color = "red")}   #should be 32 councils
+
 # flextable on hb quintiles - summary table of years and geogrpahy types present
-ft_hb_quin_check <- geo_checks %>%
+if(hb_quintiles == TRUE) {
+  ft_hb_quin_check <- geo_checks %>%
   subset(quint_type=="hb_quin") %>%
   flextable() %>%
   color(~ !is.na(S00), ~S00, color = "red") %>% # Should be no records for scotland code
   color(~ S08!=14, ~S08, color = "red") %>% # Expect 14 NHS boards for board quintiles
   color(~ !is.na(S12), ~S12, color = "red") %>% # Should be no records for council codes
   autofit()
+}
 # flextable on hb quintiles - summary table of years and geogrpahy types present
-ft_ca_quin_check <- geo_checks %>%
+if(ca_quintiles == TRUE) {
+  ft_ca_quin_check <- geo_checks %>%
   subset(quint_type=="ca_quin") %>%
   flextable() %>%
   color(~ !is.na(S00), ~S00, color = "red") %>% # Should be no records for scotland code
   color(~ S12!=32, ~S12, color = "red") %>% # Expect 14 NHS boards for board quintiles
   color(~ !is.na(S08), ~S08, color = "red") %>% # Should be no records for council codes
   autofit()
+}
 ```
 
 ### Within Scotland deprivation quintiles
-Within Scotland quintiles should return data for Scotland, nhs board and councils.<br>
+Within Scotland quintiles should return data for Scotland, and may also be available for HBs and CAs.<br>
 Table below indicates which type & how many geography codes are present & highlights if this is unexpected count
 
 ```{r}
@@ -127,57 +159,103 @@ ft_sc_quin_check
 ```
 
 ### Within health board or council deprivation quintiles
-Within hb/ca quintiles should only return data for either nhs board or councils.<br>
+If present, within hb/ca quintiles should only return data for either nhs board or councils.<br>
 Conditional formatting will show up if distinct geography counts are not as expected 
 ```{r}
 #print flextable
-ft_hb_quin_check 
-ft_ca_quin_check
+if(hb_quintiles == TRUE) {ft_hb_quin_check} else {"There are no HB-level quintiles in the data."}
+if(ca_quintiles == TRUE) {ft_ca_quin_check} else {"There are no CA-level quintiles in the data."}
 ```
 
 ------------------------------------------------------------------------------------  
 
 ##Data check 2: Expected deprivation quintiles 
+
+This section checks that all geographies that have deprivation data have the full complement of quintiles (i.e., data for 5 quintiles + a total = 6 rows). If there are any gaps these will be highlighted in the table.
+
 ###Within Health Board/Council Quintiles
 ```{r}
-# if ca or hb quintile sum not equal to 6 theres an issue (since within geography deprivation shold always have 5 quintiles plus a total)
-hbca_quintile_warning <- quintile_checks %>%
-  mutate(q_count= ifelse(quint_type!="sc_quin" && count_q!=6, TRUE, FALSE)) %>%
-  summarise(quint_error_total=sum(q_count,na.rm=TRUE))
-#Text output when ca or hb quintiles not correct
-ifelse(hbca_quintile_warning $quint_error_total == 0, "Within CA and HB quintiles all appear present :-)",
-"STOP AND CHECK....looks like not all geographies have correct number of quintiles for within CA or HB quintiles")
+
+# function to check which areas are missing one or more of the specified quintile types, by areatype
+prep_areatype_quintile_check <- function (areatype) {
+  
+  if (areatype=="Scotland") {
+    qtype <- "sc_quin"
+    warning <- sc_quintile_warning
+  } else if (areatype=="HB") {
+    qtype <- "hb_quin"
+    warning <- hb_quintile_warning
+  } else if (areatype=="CA") {
+    qtype <- "ca_quin"
+    warning <- ca_quintile_warning
+  }
+  
+  if (warning$quint_error_total != 0) { # if gaps found
+    areatype_quintile_check <- data_indicator %>%
+      subset(quint_type==qtype) %>%
+      mutate(q=paste0("Q",as.character(quintile))) %>%
+      group_by(trend_axis, areaname, code, geo_type, q, sex) %>%
+      summarise(count=n())%>%
+      spread(q, count) %>%
+      mutate(qsum=sum(any_of(Q1,Q2,Q3,Q4,Q5,QTotal), na.rm=TRUE)) %>%
+      ungroup() %>%
+      subset(qsum<6) %>%
+      arrange(geo_type,code, trend_axis) %>%
+      select(geo_type, areaname, code, trend_axis, everything()) %>%
+      flextable() %>%
+      bg(i= ~Q5==1, j= ~Q5, bg="red") %>%
+      merge_v(j=c("areaname","code","geo_type")) %>%
+      autofit() %>%
+      theme_vanilla()
+    } else {
+        "No table needed: no gaps to show."
+      }
+}
+
+# Quintile checks if hb_quin quintiles are in the data:
+if (hb_quintiles) {
+  # if hb quintile sum not equal to 6 there's an issue (since within geography deprivation should always have 5 quintiles plus a total)
+  hb_quintile_warning <- quintile_checks %>%
+    mutate(q_count = ifelse(quint_type=="hb_quin" && count_q!=6, TRUE, FALSE)) %>%
+    summarise(hb_quint_error_total=sum(q_count,na.rm=TRUE))
+  #Text output when hb quintiles not correct
+  ifelse(hb_quintile_warning$quint_error_total == 0, "There are no gaps in the HB-level quintile data. :-)",
+  "STOP AND CHECK....looks like not all geographies have correct number of HB-level quintiles.")
+prep_areatype_quintile_check("HB")
+}
+
+# Quintile checks if ca_quin quintiles are in the data:
+if (ca_quintiles) {
+  # if ca quintile sum not equal to 6 there's an issue (since within geography deprivation should always have 5 quintiles plus a total)
+  ca_quintile_warning <- quintile_checks %>%
+    mutate(q_count = ifelse(quint_type=="ca_quin" && count_q!=6, TRUE, FALSE)) %>%
+    summarise(ca_quint_error_total=sum(q_count,na.rm=TRUE))
+  #Text output when ca quintiles not correct
+  ifelse(ca_quintile_warning$quint_error_total == 0, "There are no gaps in the CA-level quintile data. :-)",
+  "STOP AND CHECK....looks like not all geographies have correct number of CA-level quintiles.")
+prep_areatype_quintile_check("CA")
+}
+
+# Message if no ca/hb quintiles are in the data:
+if(hb_quintiles==FALSE & ca_quintiles==FALSE) {
+  "There are no HB- or CA-level quintiles in the data."
+}
+
+
 ```
 
-###Within Scotland quintiles"
+
+###Within Scotland quintiles
 ```{r}
+# Are there cases where the sum of quintiles is not six (5 quintiles + a total)? How many cases?
 sc_quintile_warning <- quintile_checks %>%
   subset(quint_type=="sc_quin") %>%
   mutate(q_count= ifelse(count_q!=6, TRUE, FALSE)) %>%
   summarise(quint_error_total=sum(q_count,na.rm=TRUE))
-#Text output when one or more sc quintile is missing from an NHS Board of Council Area
- ifelse(sc_quintile_warning $quint_error_total == 0, "No geogrpahies are missing a Scotland quintile",
- paste0("STOP and check table below!...There are ", sc_quintile_warning$quint_error_total[1]," geography/time periods where not all Scotland quintiles are present.  This is most likely in small areas eg Island regions.  If many regions are affected then indicator may not be suitable for publication."))       
-# df to checkk how many areas are missing one or more scottish quintiles
-sc_quintile_check <- data_indicator %>%
-  subset(quint_type=="sc_quin") %>%
-  mutate(q=paste0("Q",as.character(quintile))) %>%
-  group_by(trend_axis, areaname, code,geo_type, q) %>%
-  summarise(count=n())%>%
-  spread(q, count) %>%
-  mutate(qsum=sum(Q1,Q2,Q3,Q4,Q5,QTotal, na.rm=TRUE)) %>%
-  ungroup() %>%
-  subset(qsum<6) %>%
-  arrange(geo_type,code, trend_axis)
-# Flextable displying which geographies and years do not ahave all scotland quintiles represented
-ft_sc_quintile_check <- sc_quintile_check %>%
-  select(geo_type, areaname, code,trend_axis, Q1:qsum) %>%
-  flextable() %>%
-  bg(i= ~Q5==1, j= ~Q5, bg="red") %>%
-  merge_v(j=c("areaname","code","geo_type")) %>%
-  autofit() %>%
-  theme_vanilla()
-ft_sc_quintile_check
+
+#Text output when one or more Scotland-wide quintile is missing from a geography represented in these data:
+prep_areatype_quintile_check("Scotland")
+
 ```
 
 ------------------------------------------------------------------------------------  
@@ -231,6 +309,7 @@ ft_sc_quintile_check
 ##Data check 4:
 ####Rates within Confidence intervals
 Do any rates fall outwith the confidence limits - they shouldn't!?
+This stage checks the CIs for the rate, the SII and the RII.
 
 ```{r, echo=FALSE}
 # Check no rates/percentages sit outside of CI range  
@@ -251,13 +330,14 @@ Look at proportion of areas and quintiles where more than 10% of row include cou
 
 ```{r}
 small_count_data <- data_indicator  %>% 
-  group_by(geo_type, quint_type, quintile, year) %>%
+  group_by(geo_type, quint_type, quintile, year, sex) %>%
   summarise(count=n(),u5=sum(numerator<5)) %>%
   mutate(percent_U5=u5/count*100,
          year =as.factor(year)) %>%
   ungroup() %>%
   subset(percent_U5>10)
-flextable(small_count_data)
+
+if(nrow(small_count_data)>0) {flextable(small_count_data)} else {"No counts less than 5."}
 ```
 
 -------------------------------------------------------------------------------
@@ -301,7 +381,8 @@ shinyApp(
       fluidRow(column(12,(p("Use dropdowns to adjust charts - remember geography code selected needs to match the quintile type")))),
       column(5,selectInput("code_selected", "Area:", choices = unique(data_indicator$code_name),multiple = FALSE, selected="S00000001: Scotland")),
      column(3,selectInput("quint_selected", "Quintile:", choices = unique(data_indicator$quint_type),multiple = FALSE, selected="sc_quin")),
-     column(3,selectInput("year_selected", "Year:", choices = unique(data_indicator$year),multiple = FALSE,selected=max(data_indicator$year)))),
+     column(3,selectInput("year_selected", "Year:", choices = unique(data_indicator$year),multiple = FALSE,selected=max(data_indicator$year))),
+     column(3,selectInput("sex_selected", "Sex:", choices = unique(data_indicator$sex),multiple = FALSE,selected="Total"))),
      fluidRow(column(8,(h3("Check annual rates by quintile and rate trends")))),
      fluidRow(
        column(6,plotlyOutput("rate_bar")),
@@ -322,8 +403,8 @@ shinyApp(
     #reactive simd trend data
     simd_trend_data<- reactive({
     rate_data <- data_indicator %>% # reactive dataset for trend chart
-    select(code,code_name, year, numerator, denominator, rate, quint_type, quintile, geo_type, par, rii, sii) %>%
-    subset(quint_type==input$quint_selected & code_name==input$code_selected) %>%
+    select(code,code_name, year, sex, numerator, denominator, rate, quint_type, quintile, geo_type, par, rii, sii) %>%
+    subset(quint_type==input$quint_selected & code_name==input$code_selected & sex == input$sex_selected) %>%
     arrange(quintile) %>% #this is needed to make palette assignments work well
     droplevels()
     })
@@ -331,7 +412,7 @@ shinyApp(
     #reactive simd data single year
     simd_singleyr_data<- reactive({
     bar_rate_data <- simd_trend_data() %>% # reactive dataset for bar chart
-     subset(year==input$year_selected) %>%
+     subset(year==input$year_selected & sex == input$sex_selected) %>%
     mutate(average=rate[quintile=="Total"]) %>%
     filter(quintile !="Total") %>%
     droplevels()

--- a/4.Data Quality Checks_inequalities indicators.Rmd
+++ b/4.Data Quality Checks_inequalities indicators.Rmd
@@ -197,7 +197,7 @@ prep_areatype_quintile_check <- function (areatype) {
       group_by(trend_axis, areaname, code, geo_type, q, sex) %>%
       summarise(count=n())%>%
       spread(q, count) %>%
-      mutate(qsum=sum(any_of(Q1,Q2,Q3,Q4,Q5,QTotal), na.rm=TRUE)) %>%
+      mutate(qsum=sum(Q1,Q2,Q3,Q4,Q5,QTotal, na.rm=TRUE)) %>%
       ungroup() %>%
       subset(qsum<6) %>%
       arrange(geo_type,code, trend_axis) %>%
@@ -207,6 +207,8 @@ prep_areatype_quintile_check <- function (areatype) {
       merge_v(j=c("areaname","code","geo_type")) %>%
       autofit() %>%
       theme_vanilla()
+    
+    areatype_quintile_check
     } else {
         "No table needed: no gaps to show."
       }
@@ -217,7 +219,7 @@ if (hb_quintiles) {
   # if hb quintile sum not equal to 6 there's an issue (since within geography deprivation should always have 5 quintiles plus a total)
   hb_quintile_warning <- quintile_checks %>%
     mutate(q_count = ifelse(quint_type=="hb_quin" && count_q!=6, TRUE, FALSE)) %>%
-    summarise(hb_quint_error_total=sum(q_count,na.rm=TRUE))
+    summarise(quint_error_total=sum(q_count,na.rm=TRUE))
   #Text output when hb quintiles not correct
   ifelse(hb_quintile_warning$quint_error_total == 0, "There are no gaps in the HB-level quintile data. :-)",
   "STOP AND CHECK....looks like not all geographies have correct number of HB-level quintiles.")
@@ -229,7 +231,7 @@ if (ca_quintiles) {
   # if ca quintile sum not equal to 6 there's an issue (since within geography deprivation should always have 5 quintiles plus a total)
   ca_quintile_warning <- quintile_checks %>%
     mutate(q_count = ifelse(quint_type=="ca_quin" && count_q!=6, TRUE, FALSE)) %>%
-    summarise(ca_quint_error_total=sum(q_count,na.rm=TRUE))
+    summarise(quint_error_total=sum(q_count,na.rm=TRUE))
   #Text output when ca quintiles not correct
   ifelse(ca_quintile_warning$quint_error_total == 0, "There are no gaps in the CA-level quintile data. :-)",
   "STOP AND CHECK....looks like not all geographies have correct number of CA-level quintiles.")


### PR DESCRIPTION
The QA script now gives the right summaries if the deprivation file has an optional sex column. It does this by adding sex="Total" to indicators without a sex column, and then grouping by sex at various points in the QA. I've also clarified that a deprivation file with quintiles at the Scotland level may or may not have lower geographies present (maybe this didn't used to be the case?) and these lower geographies may or may not have areatype-specific quintiles. The logic reflects this now. 

Testing: The QA file works for indicators with a sex column but only Scotland quintiles (run_ineq_qa("ARHS_mental_and_behav")) and also for indicators without a sex column but with HB and CA quintiles (run_ineq_qa("emergency_stays65_depr"))
