### PR TITLE
ER - Updated School Exclusions indicator script to extract and process available SIMD data.

### DIFF
--- a/School exclusion rates.R
+++ b/School exclusion rates.R
@@ -2,37 +2,23 @@
 
 # this script updates the following indicator: 13016 - School exclusion rate
 
-# numerator source (no. of exclusions): https://www.gov.scot/publications/school-exclusion-statistics/ (Table 2.1: Cases of exclusion by local authority)
+# numerator source (no. of exclusions): https://www.gov.scot/publications/school-exclusion-statistics/ INCLUDES: PUBLICLY-FUNDED LOCAL AUTHORITY SCHOOLS ONLY. NOT INCLUDING GRANT-AIDED SCHOOLS. 
 # denominator source (no. of pupils):   https://www.gov.scot/publications/pupil-census-supplementary-statistics/  (Table 5.1: Schools by local authority)
-# update file names below when new data from links above are saved in "data received" folder.
+# update file names and ranges below when new data from links above are saved in "data received" folder.
+# Latest data (2022/23) published March 2024
 
-# required packages/functions -----
-source("1.indicator_analysis.R")
+#################################################################################
+### 1. Required packages/functions -----
+#################################################################################
+source("1.indicator_analysis.R") # needed now?
+source("2.deprivation_analysis.R") # needed for the aggregated deprivation analysis
+source("functions/main_analysis.R") # needed for the QA
+source("functions/deprivation_analysis.R") # needed for the QA
+library(hablar) # for sums that ignore NA only if other values are present, otherwise it returns NA
 
-
-### 2. read in data -----
-
-# exclusions by council area (numerator)
-ca_exclusions <- read_excel(paste0(data_folder, "Received Data/School Exclusion Rates/Exclusions_202223.xlsx"), sheet = "Table 2.1", skip = 3) |> 
-  head(32) #select first 32 rows
-
-# exclusions scotland level (numerator - sits on different tab than council area figures)
-scotland_exclusions <- read_excel(paste0(data_folder, "Received Data/School Exclusion Rates/Exclusions_202223.xlsx"), sheet = "Table 1.1", skip = 3) |> 
-  filter(`Exclusion type` == "All cases of exclusion") |> #excludes breakdown of exclusion types
-  select(-`Exclusion type`) |> 
-  select(-c(1:5)) |> #excluding 02/03 to 06/07 as these not available at LA level
-  mutate("Local Authority" = "All local authorities", .before = "2007/08") 
-  
-
-# total pupils by council area (denominator)
-total_pupils <- read_excel(paste0(data_folder, "Received Data/School Exclusion Rates/Pupils_Census_2022.xlsx"), sheet = "Table 5.2", skip = 2) |>  
-  head(34) |> 
-  row_to_names(row_number = 1) #from janitor package, sets row as header by index
-
-### 3. read in lookups -----
-
-# council area lookup
-ca <- readRDS(paste0(lookups,"Geography/CAdictionary.rds")) # council area lookup
+# Read in geography lookup
+geo_lookup <- readRDS(paste0(lookups, "Geography/opt_geo_lookup.rds")) %>% 
+  select(!c(parent_area, areaname_full))
 
 # health board lookup
 hb <- readRDS(paste0(lookups, "Geography/DataZone11_All_Geographies_Lookup.rds")) %>%
@@ -40,65 +26,304 @@ hb <- readRDS(paste0(lookups, "Geography/DataZone11_All_Geographies_Lookup.rds")
   distinct(.)
 
 
+#################################################################################
+### 2. Read in data -----
+#################################################################################
 
-### 4. prepare data ------
+# file paths:
+exclusions_data <- paste0(data_folder, "Received Data/School Exclusion Rates/")
+census2022 <- paste0(exclusions_data, "Pupils_Census_2022.xlsx") # Denominators for Scotland, LAs, and SIMD 2022 
+census2020 <- paste0(exclusions_data, "Pupils_in_Scotland_2020.xlsx") # For SIMD denominators for 2020
+exclusions2022 <- paste0(exclusions_data, "Exclusions_202223.xlsx") # Numerators for Scotland and LAs
+exclusions2022_simd <- paste0(exclusions_data, "Exclusions+2022-23+supplementary+statistics+-+March.xlsx") # Numerators for SIMD in 2022
+exclusions2020_simd <- paste0(exclusions_data, "Exclusion+statistics+202021.xlsx") # Numerators for SIMD in 2020
 
-prepare_dat <- function(df, val_name) {
+
+# First: Scotland and CA data (numerators and denominators), 
+# ...then aggregate to HB and calculate the indicator.
+#################################################################################
+
+# total pupils by council area (denominator)
+total_pupils <- read_excel(census2022, sheet = "Table 5.2", skip = 4) |>  
+  head(33) |> # we want 'All local authorities' rather than 'Scotland' here, as the Scotland figure includes Grant-aided schools that are not included in the exclusions stats.
+  mutate_at(c(2:23), as.numeric) %>% 
+  pivot_longer(-c(`Local Authority`), names_to = "year", values_to = "denominator") %>%
+  mutate(year = as.numeric(substr(year, 1, 4)))
+
+# exclusions by council area (numerator)
+# (time series from 2007/08)
+ca_exclusions <- read_excel(exclusions2022, sheet = "Table 2.1", skip = 3) |> 
+  head(32) %>% #select first 32 rows (excludes all LA totals, as we get these for a longer time series from sheet Table 1.1)
+  mutate_at(c(2:11), as.numeric) %>% # some suppressed values converted to NA
+  pivot_longer(-c("Local Authority"), names_to = "trend_axis", values_to = "numerator") 
+
+# exclusions scotland level (numerator - sits on different tab than council area figures)
+# (time series from 2002/03)
+scotland_exclusions <- read_excel(exclusions2022, sheet = "Table 1.1", skip = 3) |> 
+  filter(`Exclusion type` == "All cases of exclusion") |> #excludes breakdown of exclusion types
+  mutate_at(c(2:16), as.numeric) %>% 
+  select(-`Exclusion type`) |> 
+  mutate("Local Authority" = "All local authorities") %>%
+  pivot_longer(-c("Local Authority"), names_to = "trend_axis", values_to = "numerator") 
+
+# Combine
+exclusions_ca_scot <- rbind(ca_exclusions, scotland_exclusions) %>%
+  mutate(trend_axis = substr(trend_axis, 1, 7),
+         year = as.numeric(substr(trend_axis, 1, 4))) %>%
+  mutate(`Local Authority` = gsub(" and ", " & ", `Local Authority`)) %>% # for matching with denoms
+  merge(y = total_pupils, by=c("Local Authority", "year"), all.x=T) %>% # add denoms
+  rename(areaname = `Local Authority`) %>%
+  mutate(areatype = ifelse(areaname == "All local authorities", "Scotland", "Council area"),
+         areaname = ifelse(areaname == "All local authorities", "Scotland", areaname)) %>%
+  # add the geog codes, 
+  merge(y=geo_lookup, by=c("areaname", "areatype"), all.x=TRUE) %>%  # kept all.x to check the match... produced a full match...
+  select(-starts_with("area"))
+
+exclusions_hb <- exclusions_ca_scot %>%
+  merge(y=hb, by.x="code", by.y= "ca2019") %>%
+  select(-code) %>%
+  rename(code = hb2019) %>%
+  group_by(code, trend_axis, year) |>
+  summarise_all(sum_) %>%
+  ungroup()
+
+# Process the indicator:
+exclusions_all <- rbind(exclusions_ca_scot, exclusions_hb) %>%
+  mutate(ind_id = 13016,
+         def_period = paste0("School year (", trend_axis, ")")) %>%
+  # calculate the rate and the confidence intervals (Byars method)
+  mutate(rate = numerator/denominator*1000,
+       o_lower = numerator *(1-1/9/numerator-1.96/3/sqrt(numerator))^3,
+       o_upper = (numerator+1) *(1-1/9/(numerator+1)+1.96/3/sqrt(numerator+1))^3,
+       lowci = o_lower/(denominator)*1000,
+       upci = o_upper/(denominator)*1000) %>% 
+  mutate(lowci = ifelse(is.nan(lowci), 0, lowci)) %>% # sorts out NaNs where lowci couldn't be calculated for a rate of 0
+  select(-o_lower, -o_upper) 
+
   
-  df |> 
-    # renaming/replacing values
-    rename_at(1, ~"Local Authority") |> 
-    mutate(across(-"Local Authority", ~replace(., . %in% c("c", "low", "x", "z"), 0))) %>% # replace suppression symbols with 0
-    mutate(`Local Authority` = str_replace(`Local Authority`, "&","and")) |>  #replace & with "and"
-    
-    # including council area/scotland codes
-    left_join(ca, by = c("Local Authority" = "areaname")) |>  # add in council area codes
-    mutate(code = ifelse(`Local Authority` == "All local authorities", "S00000001", code)) |>  #add in scotland code
-    
-    # reshape from wide to long to include a calendar year column
-    pivot_longer(-c("Local Authority", "code"), names_to = "year", values_to = val_name) |>  # pivot longer to create year column
-    mutate(year = as.numeric(substr(year, 1, 4))) |> # change date from FY to calendar year
-    mutate(across(-c("Local Authority", "code"), as.numeric)) |> # convert values to numeric
-    select(-`Local Authority`) #Exclude local authority name
-}
+
+# Second, get the SIMD level data: 
+#################################################################################
+
+# Available only since 2020/21
+
+# Read in the data:
+
+# 2020 
+########
+# Crude rates (cases per 1000 pupils)
+## LAs:
+la_simd_2020 <- read_excel(exclusions2020_simd, sheet = "Table 2.10", range = "A72:F104") %>% # no total row (this is obtained below)
+  mutate(trend_axis = "2020/21",
+         stat = "rate")
+## Scotland:
+scot_simd_2020 <- read_excel(exclusions2020_simd, sheet = "Table 1.11", range = "A4:F7") %>% 
+  rename(stat = 'Exclusion statistic') %>%
+  mutate(trend_axis = "2020/21",
+         "Local Authority" = "All local authorities",
+         stat = case_when(stat=="Cases of exclusion" ~ "numerator",
+                          stat=="Cases of exclusion per 1,000 pupils [note 4]" ~ "rate")) %>%
+  filter(!is.na(stat))
+# Numerators
+## LAs
+la_simd_2020_nums <- read_excel(exclusions2020_simd, sheet = "Table 2.10", range = "A4:F36") %>% # no total row (this is obtained above)
+  mutate(trend_axis = "2020/21",
+         stat = "numerator")
+
+# 2022 
+########
+# Crude rates (cases per 1000 pupils)
+## LAs and Scotland:
+la_simd_2022 <- read_excel(exclusions2022_simd, sheet = "Table 2.10", range = "A74:F107") %>% # includes a total row
+  mutate(trend_axis = "2022/23",
+         stat = "rate")
+# Numerators
+## LAs and Scotland
+la_simd_2022_nums <- read_excel(exclusions2022_simd, sheet = "Table 2.10", range = "A4:F37") %>% # includes a total row
+  mutate(trend_axis = "2022/23",
+         stat = "numerator")
 
 
-# prepare denominator data 
-denominator_data <- prepare_dat(total_pupils, "denominator")
+# Get denominators: (pupil counts, in LA schools)
+# (Available as deciles: need to sum to get quintile counts)
+
+## 2020
+la_simd_2020_denoms <- read_excel(census2020, sheet = "Table 5.10", range = "A5:K37") %>% #no total row (the Scotland value includes Grant-aided, so needs to be excluded)
+  mutate_at(c(2:11), as.numeric) %>% # some suppressed values converted to NA
+  rename(`Local Authority` = `...1`) %>%
+  group_by(`Local Authority`) %>%
+  mutate("SIMD Quintile 1" = sum_(c(`1`, `2`)),
+         "SIMD Quintile 2" = sum_(c(`3`, `4`)),
+         "SIMD Quintile 3" = sum_(c(`5`, `6`)),
+         "SIMD Quintile 4" = sum_(c(`7`, `8`)),
+         "SIMD Quintile 5" = sum_(c(`9`, `10`))) %>% # includes some zero denominators for the islands
+  ungroup() %>%
+  mutate(trend_axis = "2020/21",
+         stat = "denominator") %>%
+  select(-c(`1`:`10`))
 
 
-# prepare numerator data
-numerator_data <- bind_rows(prepare_dat(ca_exclusions, "numerator"), 
-                            prepare_dat(scotland_exclusions, "numerator"))          
-
-# combine numerator and denominator
-combined_data <- left_join(numerator_data, denominator_data, by = c("code", "year"))
-
-
-#create figures at health board level
-hb_data <- combined_data |>
-  filter(code != "S00000001") |>
-  left_join(hb, by = c("code" = "ca2019")) |>
-  select("code" = "hb2019", "numerator", "denominator", "year") |>
-  group_by(code, year) |>
-  summarise_all(sum)
-
-
-
-#combine ca, scotland and board figures
-all <- bind_rows(combined_data, hb_data) |> 
-  mutate(rate = (numerator/denominator) * 1000) #calculate crude rate
-
-
-
-#save file to be used in analyze_second() function
-saveRDS(all, paste0(data_folder, "Temporary/school_exclusions_formatted.rds"))
-
-
-
-analyze_second(filename = "school_exclusions", measure = "crude", time_agg = 1,
-               ind_id = 13016, year_type = "school", crude_rate = 1000)
+## 2022
+la_simd_2022_denoms <- read_excel(census2022, sheet = "Table 5.10", range = "A5:K37") %>% #no total row (the Scotland value includes Grant-aided, so needs to be excluded)
+  mutate_at(c(2:11), as.numeric) %>% # some suppressed values converted to NA
+  group_by(`Local Authority`) %>%
+  mutate("SIMD Quintile 1" = sum_(c(`SIMD 1`, `SIMD 2`)),
+         "SIMD Quintile 2" = sum_(c(`SIMD 3`, `SIMD 4`)),
+         "SIMD Quintile 3" = sum_(c(`SIMD 5`, `SIMD 6`)),
+         "SIMD Quintile 4" = sum_(c(`SIMD 7`, `SIMD 8`)),
+         "SIMD Quintile 5" = sum_(c(`SIMD 9`, `SIMD 10`))) %>% # includes some zero denominators for the islands
+  ungroup() %>%
+  mutate(trend_axis = "2022/23",
+         stat = "denominator") %>%
+  select(`Local Authority`, trend_axis, stat, starts_with("SIMD Q"))
 
 
 
+# Combine LA data
+la_simd_denoms <- rbind(la_simd_2020_denoms, la_simd_2022_denoms)
 
+# Aggregate to Scotland level
+scot_simd_denoms <- la_simd_denoms %>%
+  mutate(`Local Authority` = "All local authorities") %>%
+  group_by(`Local Authority`, trend_axis, stat) %>%
+  summarise_all(sum_) %>%
+  ungroup()
+
+
+# Combine the data and process
+exclusions_la_scot_simd <- rbind(la_simd_2020, scot_simd_2020, la_simd_2022, # rates
+                            la_simd_2020_nums, la_simd_2022_nums, # numerators
+                            la_simd_denoms, scot_simd_denoms) %>% # denominators (required for deriving HB data)
+  rename(areaname = "Local Authority") %>%
+  mutate(areatype = ifelse(areaname == "All local authorities", "Scotland", "Council area")) %>%
+  mutate(areaname = ifelse(areaname == "All local authorities", "Scotland", areaname)) %>%
+  # amend the spatial unit col for merging with lookup
+  mutate(areaname = case_when(areaname == "Edinburgh City" ~ "City of Edinburgh",
+                              areaname == "Eilean Siar" ~ "Na h-Eileanan Siar",
+                              TRUE ~ gsub(" and ", " & ", areaname))) %>%
+  # add the geog codes, 
+  merge(y=geo_lookup, by=c("areaname", "areatype"), all.x=TRUE) %>% # kept all.x to check the match... produced a full match...
+  # keep required columns
+  select(trend_axis, code, stat, starts_with("SIMD Q")) %>%
+  # reshape
+  pivot_longer(-c(trend_axis, code, stat), names_to = "quintile", names_prefix = "SIMD Quintile ", values_to = "value") %>%
+  mutate(value = as.numeric(value))  %>% # some suppressed values converted to NA
+  pivot_wider(names_from = stat, values_from = value) 
+
+# Make HB data
+exclusions_hb_simd <- exclusions_la_scot_simd %>%
+  merge(y=hb, by.x="code", by.y= "ca2019") %>%
+  select(-code, -rate) %>%
+  rename(code = hb2019) %>%
+  group_by(code, trend_axis, quintile) |>
+  summarise_all(sum_) %>%
+  ungroup() %>%
+  mutate(rate = 1000 * numerator/denominator)
+
+# combine all SIMD data  
+exclusions_all_simd <- rbind(exclusions_hb_simd, exclusions_la_scot_simd) %>%
+  mutate(year = as.numeric(substr(trend_axis, 1, 4)),
+         ind_id = 13016,
+         def_period = paste0("School year (", trend_axis, ")")) %>%
+  # calculate the confidence intervals (Byars method)
+  mutate(o_lower = numerator *(1-1/9/numerator-1.96/3/sqrt(numerator))^3,
+         o_upper = (numerator+1) *(1-1/9/(numerator+1)+1.96/3/sqrt(numerator+1))^3,
+         lowci = o_lower/(denominator)*1000,
+         upci = o_upper/(denominator)*1000) %>% 
+  mutate(lowci = ifelse(is.nan(lowci), 0, lowci)) %>% # sorts out NaNs where lowci couldn't be calculated for a rate of 0
+  mutate(rate = ifelse(numerator==0 & denominator==0 & is.nan(rate), 0, rate), # fix some NaN/Inf where rate and CIs should be 0
+         lowci = ifelse(numerator==0 & denominator==0  & is.nan(lowci), 0, lowci),
+         upci = ifelse(numerator==0 & denominator==0  & is.infinite(upci), 0, upci)) %>%
+  select(-o_lower, -o_upper)
+
+simd_totals <- exclusions_all %>%
+  filter(year %in% exclusions_all_simd$year) %>% # gives 94 = 2 years x (47 areanames (=1 + 32 + 14))
+  mutate(quintile = "Total") 
+
+exclusions_all_simd <- rbind(exclusions_all_simd, simd_totals) %>%
+  # drop records where a geog doesn't have the specific SIMD2020 quintile: Orkney, Shetland and Western Isles. 
+  # These have 0 numerators and rates in the data files, but should be NA
+  filter(!(code %in% c("S12000027",	"S08000026", "S12000013",	"S08000028", "S12000023",	"S08000025") & quintile=="1")) %>%
+  filter(!(code %in% c("S12000027",	"S08000026", "S12000013",	"S08000028") & quintile=="5")) %>%
+  filter(!(code %in% c("S12000013",	"S08000028") & quintile=="4")) %>%
+  filter(!is.na(denominator)) #remove suppressed denominators
+# No denominators should be zero now.
+
+# make population file for pupils by year and SIMD quintile, for inequalities metrics:
+# (checked the existing file depr_pop_schoolpupils.rds but this doesn't have HB)
+depr_pop_pupils_HB_CA_2020_2022 <- exclusions_all_simd %>%
+  select(year, code, quintile, denominator) %>%
+  mutate(quint_type = "sc_quin") 
+
+saveRDS(depr_pop_pupils_HB_CA_2020_2022, paste0(lookups, "Population/depr_pop_pupils_HB_CA_2020_2022.rds"))
+
+
+##########################################################
+### 3. Prepare final files -----
+##########################################################
+
+
+# 1 - main data (ie data behind summary/trend/rank tab)
+main_data <- exclusions_all %>% 
+  select(code, ind_id, year, 
+         numerator, rate, upci, lowci, 
+         def_period, trend_axis) %>%
+  unique() %>%
+  arrange(code, year)
+
+# Save
+write_rds(main_data, paste0(data_folder, "Data to be checked/school_exclusions_shiny.rds"))
+write.csv(main_data, paste0(data_folder, "Data to be checked/school_exclusions_shiny.csv"), row.names = FALSE) 
+
+
+# 3 - SIMD data (ie data behind deprivation tab)
+
+# Process SIMD data
+simd_data <- exclusions_all_simd %>%
+  mutate(quint_type = "sc_quin") %>%
+  select(-denominator) %>%
+  arrange(code, year, quintile)
+
+
+# Save intermediate SIMD file
+write_rds(simd_data, file = paste0(data_folder, "Prepared Data/school_exclusions_shiny_depr_raw.rds"))
+write.csv(simd_data, file = paste0(data_folder, "Prepared Data/school_exclusions_shiny_depr_raw.csv"), row.names = FALSE)
+
+# Run the deprivation analysis (saves the processed file to 'Data to be checked')
+analyze_deprivation_aggregated(filename = "school_exclusions_shiny_depr",
+                               pop = "depr_pop_pupils_HB_CA_2020_2022", # the population file created above
+                               ind_id = 13016,
+                               ind_name = "school_exclusions")
+
+##########################################################
+### 4. Run QA reports -----
+##########################################################
+
+# # Run QA reports 
+run_main_analysis_qa(filename="school_exclusions", test_file=FALSE)
+# Flagged big differences between this and the last version of the indicator.
+# These occurred for Clackmannanshire and Orkney in 2020. 
+# The values were suppressed in the original dataset, but were coded erroneously as 0 in the last version of the indicator. 
+# In the current version suppressed data are presented as NA, hence the differences observed.
+
+run_qa(type = "deprivation", filename="school_exclusions", test_file=FALSE)
+# Shows lots of missings (due to suppression) at LA level. Much less of a problem at HB level.
+# Restrict deprivation analysis to HBs and Scotland:
+simd_data <- simd_data %>%
+  filter(!(substr(code, 1, 3)=="S12"))
+
+# Save intermediate SIMD file
+write_rds(simd_data, file = paste0(data_folder, "Prepared Data/school_exclusions_shiny_depr_raw.rds"))
+write.csv(simd_data, file = paste0(data_folder, "Prepared Data/school_exclusions_shiny_depr_raw.csv"), row.names = FALSE)
+
+# Run the deprivation analysis (saves the processed file to 'Data to be checked')
+analyze_deprivation_aggregated(filename = "school_exclusions_shiny_depr",
+                               pop = "depr_pop_pupils_HB_CA_2020_2022", # the population file created above
+                               ind_id = 13016,
+                               ind_name = "school_exclusions")
+
+# run QA report again
+run_qa(type = "deprivation", filename="school_exclusions", test_file=FALSE)
+# doesn't work cos no CA data! Will check when testing in the app, but looked OK from the previous QA.
+
+##END


### PR DESCRIPTION
The data are inconsistently formatted so this is not a very elegant script. It gets the SIMD data that are available for Scotland and LAs as well as the SIMD denominators for use in the deprivation analysis function, and calculates the data for the deprivation tab. 

If a denominator is zero (e.g., in island boards where have <5 quintiles) should the row be kept (with numerator, rate and CIs all = 0) or dropped? I have dropped them here, but can reinstate if necessary.