### PR TITLE
Mm drug related admissions 2023 24

### DIFF
--- a/4.Data Quality Checks_inequalities indicators.Rmd
+++ b/4.Data Quality Checks_inequalities indicators.Rmd
@@ -221,7 +221,8 @@ prep_areatype_quintile_check <- function (areatype) {
 if (hb_quintiles) {
   # if hb quintile sum not equal to 6 there's an issue (since within geography deprivation should always have 5 quintiles plus a total)
   hb_quintile_warning <- quintile_checks %>%
-    mutate(q_count = ifelse(quint_type=="hb_quin" && count_q!=6, TRUE, FALSE)) %>%
+    subset(quint_type == "hb_quin") %>%
+    mutate(q_count = ifelse(count_q!=6, TRUE, FALSE)) %>%
     summarise(quint_error_total=sum(q_count,na.rm=TRUE))
   #Text output when hb quintiles not correct
   ifelse(hb_quintile_warning$quint_error_total == 0, "There are no gaps in the HB-level quintile data. :-)",
@@ -232,7 +233,8 @@ prep_areatype_quintile_check("HB")
 if (ca_quintiles) {
   # if ca quintile sum not equal to 6 there's an issue (since within geography deprivation should always have 5 quintiles plus a total)
   ca_quintile_warning <- quintile_checks %>%
-    mutate(q_count = ifelse(quint_type=="ca_quin" && count_q!=6, TRUE, FALSE)) %>%
+    subset(quint_type == "ca_quin") %>%
+    mutate(q_count = ifelse(count_q!=6, TRUE, FALSE)) %>%
     summarise(quint_error_total=sum(q_count,na.rm=TRUE))
   #Text output when ca quintiles not correct
   ifelse(ca_quintile_warning$quint_error_total == 0, "There are no gaps in the CA-level quintile data. :-)",

--- a/Drug related hospital stays.R
+++ b/Drug related hospital stays.R
@@ -1,4 +1,8 @@
-# ScotPHO indicators: Drug-related hospital admissions for all and for 11-25. 
+# ScotPHO indicators: Drug-related hospital admissions for all and for 11-25.
+# indicators can be updated following the release of the drug-related hospital statistics publication (typically in April)
+# Note this publication looks at combined general acute (SMR01) AND psychiatric (SMR04) drug-related stays whereas we only look at SMR01.
+# Selecting hospital type:general acute in their publication dashboard will match our figures.
+# https://publichealthscotland.scot/publications/drug-related-hospital-statistics/
 
 #   Part 1 - Extract data from SMRA.
 #   Part 2 - Create the different geographies basefiles
@@ -7,9 +11,9 @@
 ###############################################.
 ## Packages/Filepaths/Functions ----
 ###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
-source("2.deprivation_analysis.R") # deprivation function
-source("//PHI_conf/ScotPHO/Profiles/Code/stat_disclosure_drug_stays.R") # statistical disclosure methodology - confidential - do not share
+source("functions/main_analysis.R") #Normal indicator functions
+source("functions/deprivation_analysis.R") # deprivation function
+source("/PHI_conf/ScotPHO/Profiles/Code/stat_disclosure_drug_stays.R") # statistical disclosure methodology - confidential - do not share
 
 ###############################################.
 ## Part 1 - Extract data from SMRA ----
@@ -43,13 +47,13 @@ drug_hosp <- as_tibble(dbGetQuery(channel, statement= paste0(
       CASE WHEN extract(month from discharge_date) > 3 THEN extract(year from discharge_date) 
         ELSE extract(year from discharge_date) -1 END as year 
   FROM ANALYSIS.SMR01_PI z
-  WHERE discharge_date between  '1 April 2002' and '31 March 2023'
+  WHERE discharge_date between  '1 April 2002' and '31 March 2024'
       AND sex <> 9 AND sex <> 0
       AND exists (
           SELECT * 
           FROM ANALYSIS.SMR01_PI  
           WHERE link_no=z.link_no and cis_marker=z.cis_marker
-            AND discharge_date between '1 April 1997' and '31 March 2023'
+            AND discharge_date between '1 April 1997' and '31 March 2024'
             AND (regexp_like(main_condition, '", drug_diag ,"')
               OR regexp_like(other_condition_1,'", drug_diag ,"')
               OR regexp_like(other_condition_2,'", drug_diag ,"')
@@ -65,11 +69,12 @@ drug_hosp  %<>%
   summarise(age=first(age), #age, sex, postcode on hospital admission
             sex_grp=first(sex_grp), 
             pc7=first(pc7), 
-            year=max(year)) %>% ungroup() %>%  #select last discharge episode date
+            year=max(year)) %>% #select last discharge episode date
+  ungroup() %>%  
   create_agegroups() # Creating age groups for standardization.
 
 # Bringing CA and datazone info.
-postcode_lookup <- readRDS('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2023_2.rds') %>%
+postcode_lookup <- readRDS('/conf/linkage/output/lookups/Unicode/Geography/Scottish Postcode Directory/Scottish_Postcode_Directory_2025_1.rds') %>%
   setNames(tolower(names(.))) %>%  #variables to lower case
   select(pc7, datazone2001, datazone2011, ca2019)
 
@@ -80,63 +85,66 @@ drug_hosp <- left_join(drug_hosp, postcode_lookup, "pc7") %>%
 ###############################################.
 ## Part 2 - Create the different geographies basefiles ----
 ###############################################.
-###############################################.
-# Datazone2011
-drug_hosp_dz11 <- drug_hosp %>% group_by(year, datazone2011, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>%  rename(datazone = datazone2011)
 
-saveRDS(drug_hosp_dz11, file=paste0(data_folder, 'Prepared Data/drug_stays_dz11_raw.rds'))
+# Datazone2011
+drug_hosp_dz11 <- drug_hosp |>
+  group_by(year, datazone2011, sex_grp, age_grp) |>
+  summarise(numerator = n(), .groups = "drop") |>
+  rename(datazone = datazone2011)
+
+
+
+saveRDS(drug_hosp_dz11, file.path(profiles_data_folder, 'Prepared Data/drug_stays_dz11_raw.rds'))
 
 ###############################################.
 #Deprivation basefile
 # DZ 2001 data needed up to 2013 to enable matching to advised SIMD
 
-dz01_dep <- drug_hosp %>% group_by(year, datazone2001, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>% rename(datazone = datazone2001) %>% 
+dz01_dep <- drug_hosp |> 
+  group_by(year, datazone2001, sex_grp, age_grp) |> 
+  summarise(numerator = n(), .groups = "drop") |>
+  rename(datazone = datazone2001) |>
   subset(year<=2013)
 
 dep_file <- rbind(dz01_dep, drug_hosp_dz11 %>% subset(year>=2014)) #joing dz01 and dz11
 
-saveRDS(dep_file, file=paste0(data_folder, 'Prepared Data/drug_stays_depr_raw.rds'))
+saveRDS(dep_file, file.path(profiles_data_folder, 'Prepared Data/drug_stays_depr_raw.rds'))
 
 ###############################################.
 # CA (council area) file for separate indicator in CYP profile for those aged 11 to 25 years
 # Drugs publication publishes 0-14, 15-24, 25-34 only for Scotland
-drugstays_11to25 <- drug_hosp %>%
-  subset(age>=11 & age<=25) %>% 
-  group_by(year, ca2019, sex_grp, age_grp) %>%  
-  summarize(numerator = n()) %>% ungroup() %>%   
-  rename(ca = ca2019)
+drugstays_11to25 <- drug_hosp |>
+  subset(age>=11 & age<=25) |>
+  group_by(year, ca2019, sex_grp, age_grp) |>  
+  summarize(numerator = n(), .groups = "drop")
 
-saveRDS(drugstays_11to25, file=paste0(data_folder, 'Prepared Data/drug_stays_11to25_raw.rds'))
+saveRDS(drugstays_11to25, file.path(profiles_data_folder, 'Prepared Data/drug_stays_11to25_raw.rds'))
 
 ###############################################.
 ## Part 3 - Run analysis functions ----
 ###############################################.
 ##Run macros to generate HWB and Drug Profile indicator data
-analyze_first(filename = "drug_stays_dz11", geography = "datazone11", measure = "stdrate", 
-              pop = "DZ11_pop_allages", yearstart = 2002, yearend = 2022,
-              adp = TRUE, time_agg = 3, epop_age = "normal")
+main_analysis(filename = "drug_stays_dz11", geography = "datazone11", measure = "stdrate", ind_id = 20205, 
+              epop_age = "normal", epop_total = 200000, pop = "DZ11_pop_allages",
+              time_agg = 3, year_type = "financial", yearstart = 2002, yearend = 2023)
 
-analyze_second(filename = "drug_stays_dz11", measure = "stdrate", time_agg = 3, 
-               epop_total = 200000, ind_id = 20205, year_type = "financial")
 apply_stats_disc("drug_stays_dz11_shiny") # statistical disclosure applied to final values
 
 #Deprivation analysis function 
-analyze_deprivation(filename="drug_stays_depr", measure="stdrate", time_agg=3, 
-                    yearstart= 2002, yearend=2022,   year_type = "financial", 
-                    pop = "depr_pop_allages", epop_age="normal",
+deprivation_analysis(filename="drug_stays_depr", measure="stdrate", time_agg=3, 
+                    yearstart= 2002, yearend=2023, year_type = "financial", 
+                    pop_sex = "all", epop_age="normal",
                     epop_total =200000, ind_id = 20205)
+
 apply_stats_disc("drug_stays_depr_ineq")  # statistical disclosure applied to final values
 
 ###############################################.
 ##Run macros again to generate Drug related admissions in 11 to 25 year olds
-analyze_first(filename = "drug_stays_11to25", geography = "council", measure = "stdrate", 
-              pop = "CA_pop_11to25", yearstart = 2002, yearend = 2022,
-              time_agg = 3, epop_age = '11to25')
 
-analyze_second(filename = "drug_stays_11to25", measure = "stdrate", time_agg = 3, 
-               epop_total = 34200, ind_id = 13025, year_type = "financial")
+main_analysis(filename = "drug_stays_11to25", geography = "council", measure = "stdrate", ind_id = 13025,
+              pop = "CA_pop_11to25", epop_age = '11to25', epop_total = 34200,
+              year_type = "financial", time_agg = 3, yearstart = 2002, yearend = 2023)
+
 apply_stats_disc("drug_stays_11to25_shiny") # statistical disclosure applied to final values
 
 ##END


### PR DESCRIPTION
Hey @abigap01 could you please check this small PR for me? Including @vaelliott for awareness that these are being updated.

Updating the 2 drug-related hospital admissions indicators with 2023/24 data following the release of the latest drug-related hospital statistics, which came out today. 

Figures look to be in line with the publication when I filter their publication dashboard by general acute hospitals only (their main figures combine general acute and psychiatric hospitals).

Just updating date parameters, moving to the new functions and adding some additional notes. 

I also had to make 2 minor tweaks to the deprivation QA checks to get them to work.