### PR TITLE
use new data file and update up to 2023/24

### DIFF
--- a/Quit attempts - total.R
+++ b/Quit attempts - total.R
@@ -91,5 +91,11 @@ saveRDS(main_data, file.path(output_folder, "1505_smoking_quit_attempts_shiny.rd
 write.csv(main_data, file.path(output_folder, "1505_smoking_quit_attempts_shiny.csv"), row.names = FALSE)
 
 
+# run qa report
+run_qa(filename="1505_smoking_quit_attempts", type="main", test_file = FALSE)
+#note that indicator is a count of quit attempts and numerator (ie number of quit attempts is set to be rate and measure).
+
+
+
 ## END
 

--- a/Quit attempts - total.R
+++ b/Quit attempts - total.R
@@ -1,59 +1,95 @@
-# ScotPHO indicators: Quit attempts total number
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# Analyst notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~
 
-#   Part 1 - Create basefile
-#   Part 2 - Run analysis function
-#   Part 3 - Format the file for Shiny tool
+# This script updates the following indicator:
+# 1505 - Smoking quit attempts
 
-###############################################.
-## Packages/Filepaths/Functions ----
-###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
+# data provided annually by the PHS smoking team following release of below publication (typically in december):
+# https://publichealthscotland.scot/publications/nhs-stop-smoking-services-scotland/
 
-###############################################.
-## Part 1 - Create basefile ----
-###############################################.
-#Reading data extracted from table from Smoking cessation annual publication
-quit_total <- read_csv(paste0(data_folder, "Received Data/Smoking quit attempts/quit_attempts_total_2022.csv")) %>% 
-  setNames(tolower(names(.))) %>%    #variables to lower case
-  gather("year", "numerator", -council) %>% #from wide to long format
-  mutate(year = substr(year,1,4)) #fin year
+# data provided at council, board and scotland level, split by SIMD quintile. 
+# Council and board data provided for both local and scottish quintiles
+# all data based on patients council of residence
 
-# converting council names into codes. First bring lookup.
-ca_lookup <- readRDS("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds") %>% 
-  setNames(tolower(names(.))) %>% #set variables to lower case
-  rename(ca=code)
+# indicator can be updated at the same time as the 3 smoking quit rate indicators
+# as all use the same basefile. They are updated from separate R scripts due to 
+# some differences required in indicator production steps
 
-quit_total <- left_join(quit_total, ca_lookup, 
-                        by = c("council" = "areaname")) %>% 
-  select(-council) %>% 
-  mutate(denominator = NA_integer_) # needed for the function
+# Although data is available by SIMD, we do not do SIMD splits for this particular
+# indicator as measure is just a count of quit attempts. SIMD splits are
+# done for the other quit rate (%) indicators.
 
-saveRDS(quit_total, file=paste0(data_folder, 'Prepared Data/quitattempts_total_raw.rds'))
+# note we used to publish data from 2009/10 onwards, however 
+# data now only available from 2014/15 due to data quality issues in Glasgow prior to this
 
-###############################################.
-## Part 2 - Run first analysis functions ----
-###############################################.
-# to generate geographical aggregations
-analyze_first(filename = "quitattempts_total", geography = "council", 
-              measure = "percent", yearstart = 2009, yearend = 2021, time_agg = 1)
+# Data splits:
+# Main - Yes
+# Deprivation - No
+# Pop groups - No
 
-###############################################.
-## Part 3 - Format the file for Shiny tool ----
-###############################################.
-quit_total <- readRDS(file=paste0(data_folder, "Temporary/quitattempts_total_formatted.rds")) %>% 
-  #creating labels and indicator id
-  mutate(trend_axis = paste0(year, "/", substr(year+1, 3, 4)),
-         def_period = paste0(trend_axis, " financial year"),
-         ind_id = 1505, 
-         lowci = NA_real_, 
-         upci = NA_real_, 
-         rate = numerator) %>%  # use numerator as rate to ensure plots correctly in profiles tool
-  # mutate_at(c("lowci", "upci", "rate"),  ~NA_real_) %>% #empty for tool
-  select(-denominator) %>% 
-  filter(!is.na(code)) #taking out empty rows
+# Indicator production Steps:
+# Part 1 - Housekeeping
+# Part 2 - Read in and clean data 
+# Part 3 - Prepare and save final file
 
-#Preparing data for Shiny tool. Including both rds and csv file for now
-saveRDS(quit_total, paste0(data_folder, "Data to be checked/quitattempts_total_shiny.rds"))
-write_csv(quit_total, paste0(data_folder, "Data to be checked/quitattempts_total_shiny.csv"))
 
-##END
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 1 - Housekeeping ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+source("functions/main_analysis.R") # load function to access profiles data filepath
+library(arrow) # for reading parquet files
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 2 - Read in and tidy up data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# get path to data file provided by smoking team
+filepath <- file.path(profiles_data_folder, "Received Data", "Smoking quit attempts", "scotpho_simd_data.parquet")
+
+# read in data 
+data <- read_parquet(filepath) |>
+  # temporary step May 2025: remove 2024/25 data as incomplete
+  # either replace with 2025/26 at next update if required or remove
+  filter(finyear != "2024/25")
+
+# get totals for each year and geography
+data <- data |>
+  filter(sim_type == "simd_sc") |>
+  group_by(finyear, geographic_code) |>
+  summarise(numerator = sum(number_all_quit_attempts), .groups = "drop") |>
+  # remove NA geographies - already included in scotland totals
+  filter(!is.na(geographic_code)) |>
+  # recode scotland geography code
+  mutate(geographic_code = if_else(geographic_code == "S92000003", "S00000001", geographic_code))
+  
+  
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 3 - Prepare final file ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# adding/renaming columns to ensure in format required before saving final file 
+main_data <- data |>
+  rename(code = geographic_code,
+         trend_axis = finyear) |>
+  mutate(rate = numerator,
+         upci = NA,
+         lowci = NA,
+         year = as.numeric(substr(trend_axis,1, 4)),
+         def_period = trend_axis,
+         ind_id = "1505") 
+
+
+# folder to save final files
+output_folder <- file.path(profiles_data_folder, "Data to be checked")
+
+# save final files as csv and rds
+saveRDS(main_data, file.path(output_folder, "1505_smoking_quit_attempts_shiny.rds"))
+write.csv(main_data, file.path(output_folder, "1505_smoking_quit_attempts_shiny.csv"), row.names = FALSE)
+
+
+## END
+

--- a/Quit attempts 4 weeks.R
+++ b/Quit attempts 4 weeks.R
@@ -1,83 +1,147 @@
-# ScotPHO indicators: Quit attempts at 4 weeks (including quintile indicators)
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# Analyst notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~
 
-#   Part 1 - Create basefile for general indicator
-#   Part 2 - Create basefiles for quintile indicators
-#   Part 3 - Run analysis functions
+# This script updates the following indicator:
+# 1536 - Smoking quit rate at 4 weeks follow-up
 
-###############################################.
-## Packages/Filepaths/Functions ----
-###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
+# data provided annually by the PHS smoking team following release of below publication (typically in december):
+# https://publichealthscotland.scot/publications/nhs-stop-smoking-services-scotland/
 
-###############################################.
-## Part 1 - Create basefile for general indicator ----
-###############################################.
+# data provided at council, board and scotland level, split by SIMD quintile. 
+# Council and board data provided for both local and scottish quintiles
+# all data based on patients council of residence
 
-#Reading data extracted from table from Smoking cessation annual publication
-quit_4weeks <- read_csv(paste0(data_folder, "Received Data/quit_attempts_4weeks_2022.csv")) %>% 
-  setNames(tolower(names(.))) %>%    #variables to lower case
-  gather("year", "numerator", -council) %>% #from wide to long format
-  mutate(year = substr(year,1,4))
+# note this indicator can be updated at the same time as the 3 other smoking quits indicators
+# as they all use the same basefile. They are updated from separate R scripts due to 
+# some differences required in indicator production steps
 
-#the total number of quit attempts is the denominator 
-quit_total <- read_csv(paste0(data_folder, "Received Data/quit_attempts_total_2022.csv")) %>% 
-  setNames(tolower(names(.))) %>%    #variables to lower case
-  gather("year", "denominator", -council) %>% #from wide to long format
-  mutate(year = substr(year,1,4))
+# note we used to publish data from 2009/10 onwards, however 
+# data now only available from 2014/15 due to data quality issues in Glasgow prior to this
 
-# merging numerator and denominator
-quit_4weeks <- left_join(quit_4weeks, quit_total, by = c("year", "council"))
-
-# converting council names into codes. First bring lookup.
-ca_lookup <- readRDS("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds") %>% 
-  setNames(tolower(names(.))) %>% rename(ca=code)
-
-quit_4weeks <- left_join(quit_4weeks, ca_lookup, by = c("council" = "areaname")) %>% 
-  select(-council)
-
-saveRDS(quit_4weeks, file=paste0(data_folder, 'Prepared Data/quitattempts_4weeks_raw.rds'))
-
-###############################################.
-## Part 2 - Create basefiles for quintile indicators ----
-###############################################.
-
-# Reading council quintile data requested to smoking cessation team
-quit4w_quint <- read.spss(paste0(data_folder, "Received Data/Smoking_Cessation_Council_SIMD_FY2009-10 to FY2019-20.sav"),
-                          to.data.frame=TRUE, use.value.labels=FALSE) %>% 
-  setNames(tolower(names(.))) %>%    #variables to lower case
-  filter(scsimdquintile != 99) %>% #excluding unknown values
-  rename(ca = ca2011, numerator = four_week_quit, denominator = quit_attempt, year = finyear) %>% 
-  mutate(year = substr(year,1,4))
-
-for (quint in 1:5) { #creating files for each one of the quintiles
-  quit4w_quint_raw <- quit4w_quint %>% filter(scsimdquintile == quint) %>% 
-    select(-scsimdquintile) 
-  
-  saveRDS(quit4w_quint_raw, 
-          paste0(data_folder, "Prepared Data/quitattempts_4weeks_quint", quint, "_raw.rds"))
-  
-}
-
-###############################################.
-## Part 3 - Run analysis functions ----
-###############################################.
-analyze_first(filename = "quitattempts_4weeks", geography = "council", hscp = T,
-              measure = "percent", yearstart = 2009, yearend = 2021, time_agg = 1)
-
-analyze_second(filename = "quitattempts_4weeks", measure = "percent", time_agg = 1, 
-               ind_id = 1536, year_type = "financial")
-
-# For quintile indicators 
-# Names of the files used in the next two functions
-filenames <- c("quitattempts_4weeks_quint1", "quitattempts_4weeks_quint2",
-               "quitattempts_4weeks_quint3","quitattempts_4weeks_quint4",
-               "quitattempts_4weeks_quint5") 
-
-mapply(analyze_first, filename = filenames, geography = "council", 
-       measure = "percent", yearstart = 2009, yearend = 2021, time_agg = 1)
-
-mapply(analyze_second, filename = filenames, measure = "percent", time_agg = 1, qa = F,
-       ind_id = c(1539:1543), year_type = "financial")
+# Data splits:
+# Main - Yes
+# Deprivation - Yes
+# Pop groups - No
 
 
-##END
+# Indicator production Steps:
+# Part 1 - Housekeeping
+# Part 2 - Read in and clean data 
+# Part 3 - Create main indicator file 
+# Part 4 - create deprivation file
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 1 - Housekeeping ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+source("functions/main_analysis.R") # source main analysis function 
+source("functions/deprivation_analysis.R") # source deprivation function 
+library(arrow) # for reading parquet files
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 2 - Read in and clean data  ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# get path to data file provided by smoking team
+filepath <- file.path(profiles_data_folder, "Received Data", "Smoking quit attempts", "scotpho_simd_data.parquet")
+
+# read in data 
+data <- read_parquet(filepath) |>
+  # temporary step May 2025: remove 2024/25 data as incomplete
+  # either replace with 2025/26 at next update if required or remove
+  filter(finyear != "2024/25")
+
+# remove NA geography codes - already included in scotland totals
+data <- data |>
+  filter(!is.na(geographic_code))
+
+
+# create 'total' rows for each group
+# step required as data split by simd quintile (Q1-5 + unknown)
+data <- data |>
+  group_by(finyear, geographic_level, geographic_code, sim_type) |>
+  group_modify(~ .x |> adorn_totals()) |>
+  ungroup() |>
+  filter(simd != "Unknown") # remove unknown quintiles after calculating totals
+
+
+# get starting year from fin year
+data <- data |>
+  mutate(year = as.numeric(substr(finyear, 1, 4)))
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 3 - Create main indicator file ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+main_data <- data |>
+  # filter on council area totals
+  filter(simd == "Total" & sim_type == "simd_sc" & geographic_level == "ca") |>
+  # select and rename required columns
+  select(
+    year, 
+    geographic_code, 
+    numerator = number_all_4_week_quits, 
+    denominator = number_all_quit_attempts
+  )
+
+# save temp file to be used in main_analysis function 
+saveRDS(main_data, file.path(profiles_data_folder, "Prepared Data", "1536_quit_rate_4weeks_raw.rds"))
+
+# run analysis function 
+main_analysis(filename = "1536_quit_rate_4weeks", ind_id = "1536", measure = "percent", geography = "council", 
+              time_agg = 1, year_type = "financial",yearstart = 2014, yearend = 2023)
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 4 - create deprivation file ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Data already aggregated at HB, CA, Scotland level for each SIMD quintile and quint type
+# so no need to run through the deprivation_analysis function
+# the steps below calculate rates and ensure all variables/values in required format for final file
+
+# rename quint columns and recode quint type values
+simd_data <- data |>
+  rename("quintile" = "simd",
+         "quint_type" = "sim_type") |>
+  mutate(quint_type = case_when(quint_type == "simd_sc" ~ "sc_quin",
+                                quint_type == "simd_ca" ~ "ca_quin",
+                                quint_type == "simd_hb" ~ "hb_quin", TRUE ~ "unknown"))
+
+# recode scotland geography code
+simd_data <- simd_data |>
+  mutate(geographic_code = if_else(geographic_code == "S92000003", "S00000001", geographic_code))
+
+
+# prepare final deprivation file
+simd_data <- simd_data |>
+  # select and rename columns
+  select(
+    year, 
+    code = geographic_code, 
+    numerator = number_all_4_week_quits, 
+    denominator = number_all_quit_attempts,
+    quint_type,
+    quintile
+  ) |>
+  # calculate % rate 
+  calculate_percent() |>
+  # caculate SII/RII/PAR
+  calculate_inequality_measures() |>
+  # add columns required for final file 
+  mutate(ind_id = "1536") |>
+  create_trend_axis_column(year_type = "financial", agg = 1) |>
+  create_def_period_column(year_type = "financial", agg = 1)
+
+# save final deprivation file
+saveRDS(simd_data, file.path(profiles_data_folder, "Data to be checked", "1536_quit_rate_4weeks_depr_ineq.rds"))
+
+
+# QA deprivation file 
+run_qa(filename = "1536_quit_rate_4weeks_depr", type = "deprivation", test_file = FALSE)
+
+
+## END

--- a/Quit attempts from pregnant smokers.R
+++ b/Quit attempts from pregnant smokers.R
@@ -18,6 +18,12 @@
 # is larger than the number of pregnant smokers (denominator). There's also a lot of >5 numerators
 # Data is still prepared below in format required to to SIMD splits, incase position changes in the future.
 
+# Important to remember that this metric has some potential flaws in data collection
+# the number of pregnant smokers is based on self-reported smoking status at antenatal booking
+# It is possible that not all women who are pregnant report their smoking status or smoking status could changes during pregnancy
+# It is also possible that women may attempt to quit smoking in early stages of pregnancy before completing antenatal booking
+# several factors may explain why numerator may be higher than denominators
+
 # Data splits:
 # Main - Yes
 # Deprivation - No
@@ -48,6 +54,7 @@ library(phsopendata) # for extracting opendata
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # extract data from opendata platform
+# https://www.opendata.nhs.scot/dataset/births-in-scottish-hospitals/resource/e87a7673-0397-43ca-91a5-166184319728%20%20e87a7673-0397-43ca-91a5-166184319728
 preg_smokers <- get_resource(res_id = "e87a7673-0397-43ca-91a5-166184319728", row_filters = list(SmokingAtBooking = "Current smoker")) |>
   clean_names()
 
@@ -160,7 +167,7 @@ saveRDS(main_data, file.path(profiles_data_folder, "Prepared Data", "1526_quit_a
 main_analysis(filename = "1526_quit_attempts_pregnant", ind_id = 1526, geography = "council", 
               measure = "percent", yearstart = 2014, yearend = 2023, time_agg = 3, year_type = "financial")
 
-
+run_qa(filename="1526_quit_attempts_pregnant", type="main", test_file=FALSE)
 
 
 # # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Quit attempts from pregnant smokers.R
+++ b/Quit attempts from pregnant smokers.R
@@ -1,75 +1,213 @@
-# Analyst notes ----------------------------------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~
+# Analyst notes -----
+# ~~~~~~~~~~~~~~~~~~~~~~
 
 # This script updates the following indicator:
 # 1526 - Smoking quit attempts from pregnant smokers
 
-# Data should be requested from the drugs and alcohol team alongside a range of other quit attempts data extracts
-# The numerator is provided from the drugs and alcohol team
-# The denominator comes from data published on the open data platform by the maternity team (Smoking behaviour during pregnancy) 
+# denominator - quit attempts from pregnant smokers (data provided annually by the PHS smoking team)
+# numerator - total pregnant smokers (data extracted from PHS open data platform)
+
+# Pregnant smoking data still uses SMR02. Pregnancy team recently switch their data source
+# to the antenatal booking collection data (ABC) which only has 2 years worth of data to report on.
+# Need to check if the open data using SMR02 will be updated going forward of if we need to switch to ABC
+# and shorten the ime series of this indicator
+
+# note that although data is available by SIMD quintile we cannot calculate
+# rates at this level as there are instances where the number of pregnant quit attempts (numerator)
+# is larger than the number of pregnant smokers (denominator). There's also a lot of >5 numerators
+# Data is still prepared below in format required to to SIMD splits, incase position changes in the future.
+
+# Data splits:
+# Main - Yes
+# Deprivation - No
+# Pop groups - No
+
+# Indicator production Steps:
+# Part 1 - housekeeping 
+# Part 2- Prepare numerator data
+# Part 3 - Prepare denominator data
+# Part 4 - combine numerator and denominator
+# Part 5 - Create main data file 
+# Part 6 - Create deprivation data file (current commented out)
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 1 - Housekeeping ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+source("functions/main_analysis.R")
+source("functions/deprivation_analysis.R")
+library(arrow) # for reading parquet files
+library(phsopendata) # for extracting opendata
+
+# uncomment and run line below if need to install phsopendata package
+# remotes::install_github("Public-Health-Scotland/phsopendata", upgrade = "never")
 
 
-# Part 1 - read in data
-# Part 2 - prepare data
-# Part 3 - run analysis functions 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 2 - Prepare numerator data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# dependencies -----------------------------------------------------------------
-source("1.indicator_analysis.R")
-library(tidyr) # for pivoting 
+# extract data from opendata platform
+preg_smokers <- get_resource(res_id = "e87a7673-0397-43ca-91a5-166184319728", row_filters = list(SmokingAtBooking = "Current smoker")) |>
+  clean_names()
 
-
-
-# 1. read in data --------------------------------------------------------------
-
-# numerator (number of quit attempts from pregnant smokers)
-numerator <- read_csv(paste0(data_folder, "Received Data/Smoking quit attempts/2023 request/pregnant_quit_attempts_2022.csv")) %>%
-  setNames(tolower(names(.))) 
-
-# denominator (number of pregnant smokers)
-denominator <- read_csv("https://www.opendata.nhs.scot/dataset/df10dbd4-81b3-4bfa-83ac-b14a5ec62296/resource/e87a7673-0397-43ca-91a5-166184319728/download/11.4_smoking.csv") %>%
-  setNames(tolower(names(.))) 
-
-
-
-# 2. Prepare data --------------------------------------------------------------
-
-# prepare numerator data
-numerator <- numerator %>%
-  select(-council) %>%
-  pivot_longer(!ca2019, names_to = "year", values_to = "numerator") %>%
-  rename(ca = ca2019) %>%
-  mutate(year = substr(year, start = 1, stop = 4))
+# clean data 
+preg_smokers <- preg_smokers |>
+  # get starting year of finyear and filter from 2014 onwards
+  # to match smoking quit attempts data 
+  mutate(year = as.numeric(substr(financial_year, 1, 4))) |>
+  filter(year >=2014) |>
+  # aggregate to get total number of pregnant smokers per year, council and simd quintile
+  group_by(year, financial_year, ca, simd_quintile) |>
+  summarise(number_pregnant_smokers = sum(maternities), .groups = "drop")|>
+  # get overall totals per year and council (i.e. no simd split)
+  group_by(year, financial_year, ca) |>
+  group_modify(~ .x |> adorn_totals()) |>
+  filter(!simd_quintile == " ") |>
+  ungroup() |>
+  # rename simd column to that required in our final files
+  rename("simd" = "simd_quintile") |>
+  # add a quint type column 
+  mutate(sim_type = "simd_sc")
 
 
-# prepare denominator data
-denominator <- denominator %>%
-  filter(smokingatbooking == "Current smoker") %>%
-  mutate(year = substr(financialyear, start = 1, stop = 4)) %>%
-  filter(year >= 2011) %>%
-  rename(denominator = maternities) %>%
-  select(ca, year, denominator) %>%
-  group_by(ca, year) %>%
-  summarise_all(sum) %>%
-  ungroup() %>%
-  filter(ca != "RA2704") # exclude no fixed abode
+# get geography lookup and prepare at HB/CA level
+geo_lookup <- readRDS(file.path(profiles_lookups, "Geography", "DataZone11_All_Geographies_Lookup.rds")) |>
+  select(ca2019, hb2019) |>
+  unique()
+
+# join data with lookup and pivot data longer so just 1 geography code column 
+# calculate number of pregnany smokers for each geography, year and simd quintile
+preg_smokers <- left_join(preg_smokers, geo_lookup, by = c("ca" = "ca2019")) |>
+  mutate(scotland = "S00000001") |>
+  pivot_longer(cols = c("ca", "hb2019", "scotland"), names_to = NULL, values_to = "geographic_code") |>
+  group_by(year, financial_year, simd, sim_type, geographic_code) |>
+  summarise_all(sum) |>
+  ungroup() |>
+  # remove unknown geographies - now included in scotland totals
+  filter(!is.na(geographic_code) & geographic_code != "RA2704")
+  
 
 
-# combine numerator and denominator
-combined <- left_join(numerator, denominator, by = c("ca", "year"))
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 3 - prepare denominator data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# get path to data file provided by smoking team
+filepath <- file.path(profiles_data_folder, "Received Data", "Smoking quit attempts", "scotpho_simd_data.parquet")
+
+# read in data 
+quit_attempts <- read_parquet(filepath) |>
+  # temporary step May 2025: remove 2024/25 data as incomplete
+  # either replace with 2025/26 at next update if required or remove
+  filter(finyear != "2024/25")
+  
+# remove NAs
+quit_attempts <- quit_attempts |>
+  filter(!is.na(geographic_code))
 
 
-# save file to pass to functions 
-saveRDS(combined, file=paste0(data_folder, 'Prepared Data/quitattempts_pregnant_raw.rds'))
+# create 'total' rows for each group
+# step required as data split by simd quintile (Q1-5 + unknown)
+quit_attempts <- quit_attempts |>
+  group_by(finyear, geographic_level, geographic_code, sim_type) |>
+  group_modify(~ .x |> adorn_totals()) |>
+  ungroup() |>
+  filter(simd != "Unknown") # remove unknown quintiles after calculating totals
+
+
+# get starting year from fin year
+quit_attempts <- quit_attempts |>
+  mutate(year = as.numeric(substr(finyear, 1, 4)))
+
+
+# filter on scottish quintiles only 
+# as pregnant smokers data not available for local quintiles
+quit_attempts <- quit_attempts |>
+  filter(sim_type == "simd_sc")
+
+quit_attempts <- quit_attempts |>
+  select(year, finyear, geographic_code,sim_type, simd, number_pregnant_quit_attempts)
+
+
+# recode scotland 
+quit_attempts <- quit_attempts |>
+  mutate(geographic_code = if_else(geographic_code == "S92000003", "S00000001", geographic_code))
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 4 - combine numerator and denominator  ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+preg_quit_attempts <- left_join(preg_smokers, quit_attempts) |>
+  rename(numerator = number_pregnant_quit_attempts,
+         denominator = number_pregnant_smokers) |>
+  mutate(numerator = if_else(is.na(numerator), 0, numerator))
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Part 5 - create main file ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# get council area totals
+main_data <- preg_quit_attempts |>
+  filter(simd == "Total" & grepl("S12", geographic_code)) |>
+  select(year, geographic_code, numerator, denominator)
+
+# save temp file 
+saveRDS(main_data, file.path(profiles_data_folder, "Prepared Data", "1526_quit_attempts_pregnant_raw.rds"))
+
+# run analysis function 
+main_analysis(filename = "1526_quit_attempts_pregnant", ind_id = 1526, geography = "council", 
+              measure = "percent", yearstart = 2014, yearend = 2023, time_agg = 3, year_type = "financial")
 
 
 
 
-# 3. Run analysis functions ----------------------------------------------------
-analyze_first(filename = "quitattempts_pregnant", geography = "council", 
-              measure = "percent", yearstart = 2011, yearend = 2021, time_agg = 3)
-
-
-analyze_second(filename = "quitattempts_pregnant", measure = "percent", time_agg = 3, 
-               ind_id = 1526, year_type = "financial")
-
-
-# END
+# # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# # Part 6 - create deprivation file ----
+# # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 
+# # unable to split by
+# 
+# # Data already aggregated at HB, CA, Scotland level for each SIMD quintile and quint type
+# # so no need to run through the deprivation_analysis function
+# # the steps below calculate rates and ensure all variables/values in required format for final file
+# 
+# # rename quint columns and values
+# simd_data <- preg_quit_attempts |>
+#   rename("quintile" = "simd",
+#          "quint_type" = "sim_type"
+#   ) |>
+#   mutate(quint_type = case_when(quint_type == "simd_sc" ~ "sc_quin",
+#                                 quint_type == "simd_ca" ~ "ca_quin",
+#                                 quint_type == "simd_hb" ~ "hb_quin", TRUE ~ "unknown"))
+# 
+# # prepare final deprivation file
+# simd_data <- simd_data |>
+#   # select and rename columns
+#   select(
+#     year,
+#     code = geographic_code,
+#     numerator,
+#     denominator,
+#     quint_type,
+#     quintile
+#   ) |>
+#   # calculate rate
+#   calculate_percent() |>
+#   # caculate SII/RII/PAR
+#   calculate_inequality_measures() |>
+#   # add columns required for deprivation final file
+#   mutate(ind_id = "1526") |>
+#   create_trend_axis_column(year_type = "financial", agg = 1) |>
+#   create_def_period_column(year_type = "financial", agg = 1)
+# 
+# # save final deprivation file
+# saveRDS(simd_data, file.path(profiles_data_folder, "Data to be checked", "1526_quit_attempts_pregnant_depr_ineq.rds"))
+# 
+# 
+# # QA deprivation file
+# run_qa(filename = "1526_quit_attempts_pregnant_depr", type = "deprivation", test_file = FALSE)
+# 
+# 
+# ## END


### PR DESCRIPTION
Updating the 4 smoking quit indicators to go up to 2023/24 using new data file provided by smoking team that includes SIMD splits by scottish and local quintiles:

- Smoking quit attempts (count)
- Smoking quit rate at 12 weeks follow up (%)
- Smoking quit rate at 4 weeks follow up (%)
- Smoking quit attempts from pregnant smokers (%)

The smoking quit rate at 4 weeks used to be split into 5 indicators (overall rate plus a rate for each quintile) so this has now been converted into just 1 indicator with a main file and deprivation file. We now also have deprivation data for quit rate at 12 weeks.

The pregnant smokers data had instances where the denominator (total pregnant smokers) was smaller than the numerator (quit attempts from pregnant smokers). When I run the deprivation QA it was also flagging that a lot of the numbers were very small so wasn't sure it was sensible to split this indicator by SIMD, but I've kept the code in and uncommented if anyone wants to sense check my thinking?

There's some code repetition across these scripts but given differences in splits and use of analysis functions I think it still makes sense to keep them as separate scripts even though they share the same base file.



