### PR TITLE
update to include 2023

### DIFF
--- a/Children looked after by local authority.R
+++ b/Children looked after by local authority.R
@@ -1,4 +1,11 @@
-### Indicator name and definition -----------------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Analyst notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# MM note June 2025 - when CA population lookups are updated to include 2024
+# this script can be re-run. Just need to change 'year_end' parameter to 2024 in the 
+# main_analysis function as the steps below already prepare the 2024 numerator data
+# year_end parameter currently set to 2023 to filter out 2024 records until populations (denominator) are ready
 
 # This script prepares data for the following indicator:-
 # 20503 - Children looked after by local authority
@@ -7,50 +14,125 @@
 # Children looked after by the local authority; number and rate per 1,000 children aged 0-17 years.
 # based on children looked after as at 31 July when snapshot taken
 
-#   Part 1 - extract data and format to be used in analysis functions
-#   Part 2 - Run analysis functions 
+# Trend data used to be extracted solely from statistics.gov.scot using the opendatascot R package
+# However, due to delays in that platform being updated, we have to use a combination 
+# of open data (2009 - 2022) and data from two publication (for 2023 and 2024 data)
+# from the childrens social work statistics (additional tables):
+
+# 2023 data
+# https://www.gov.scot/publications/childrens-social-work-statistics-2022-23-looked-after-children/
+
+# 2024 data
+# https://www.gov.scot/publications/childrens-social-work-statistics-looked-after-children-2023-24/documents/
+
+# Review this as at next update as statistics.gov.scot platform may have been updated:
+# https://statistics.gov.scot/resource?uri=http%3A%2F%2Fstatistics.gov.scot%2Fdata%2Flooked-after-children
 
 
+#   1. load/install packages and functions
+#   2. Extract open data
+#   3. Read in publication tables data
+#   4. Prepare data file for analysis
+#   5. run analysis function
 
-### Analyst notes ---------------------------------------------------------------
 
-# Data is extracted using the 'opendatascot' package
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 1. Load/install Packages and functions ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+source("functions/main_analysis.R") # for creating main dataset indicator file 
+library(opendatascot) # for extracting data from statistics.gov.scot
+library(readxl) # for reading in excel files
+library(data.table) # for rbindlist() function to combine excel files
+
 
 # uncomment the 2 lines below to install package if required:-
 # install.packages("devtools")
 # devtools::install_github("datasciencescotland/opendatascot")
 
 
-### Part 1 - extract and prepare data ------------------------------------------
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 2. Extract open data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# 1.a load dependencies/functions ----
-source("1.indicator_analysis.R") 
-library(opendatascot)
+# extract data 
+opendata_extract <- ods_dataset("looked-after-children", 
+                                measureType="count",
+                                residentialStatus = "all",
+                                geography = "la") 
 
 
-#1.b extract data ----
-looked_after_children <- opendatascot::ods_dataset("looked-after-children",
-                                                   measureType="count",
-                                                   residentialStatus = "all",
-                                                   geography = "la") 
-
-#1.c format data ----
-looked_after_children  %<>%
-  select(ca = refArea, year = refPeriod, numerator = value) %>%
-  mutate(across(c("year", "numerator"), as.numeric))
+# select/rename columns and change column classes
+opendata_extract  <- opendata_extract |>
+  select(code = refArea, 
+         year = refPeriod, 
+         numerator = value)
   
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 3. Read in publication tables data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# name of folder where tables have been saved
+folder <- file.path(profiles_data_folder, "Received Data", "Looked after children")
+
+# full filepath for each file in folder 
+files <- list.files(folder, full.names = TRUE)
+
+# read in and combine 'Table 3.2 'from different years publications
+# excel files must be closed or you'll get an error!
+pub_tables <- rbindlist(lapply(files, function(x) {
+  read_xlsx(x, sheet = "Table 3.2", skip = 4) |>
+    mutate(file = basename(x))
+  }))
+
+
+# create year column taking the end year of the financial year
+# as the data on looked after children is based on a snapshot in 
+# July which falls in the 2nd year of the FY 
+pub_tables <- pub_tables |>
+  mutate(year = case_when(
+    grepl("2022-23", file) ~ 2023,
+    grepl("2023-24", file) ~ 2024,
+    .default = NA)
+    )
+
+
+# read in council area lookup containing geography codes
+ca_dictionary <- readRDS(file.path(profiles_data_folder, "Lookups", "Geography", "CAdictionary.rds"))
+
+# join with lookup 
+pub_tables <- pub_tables |>
+  inner_join(ca_dictionary, by = c("Local authority" = "areaname"))
+
+
+
+# select/rename required cols
+pub_tables <- pub_tables |>
+  select(year,code, numerator = `Total number of children looked after`)
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 4. Prepare data file for analysis ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# combine open data and publication data to get full time series
+data_combined <- bind_rows(pub_tables, opendata_extract)
   
-  
-#1.d save file to be used in analysis functions ------
-saveRDS(looked_after_children, file=paste0(data_folder, 'Prepared Data/looked_after_raw.rds'))
+# save file to be used in analysis function
+saveRDS(data_combined, file.path(profiles_data_folder, 'Prepared Data/looked_after_raw.rds'))
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# 5. run analysis function ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+main_analysis(filename = "looked_after", ind_id = 20503, geography = "council", 
+              measure = "crude", pop = "CA_pop_under18", crude_rate = 1000,
+              yearstart = 2009, yearend = 2023, time_agg = 1, year_type = "snapshot")
 
 
 
-### Part 2 - Run analysis functions  ---------------------------------
-analyze_first(filename = "looked_after", geography = "council", pop = "CA_pop_under18",
-              measure = "crude", yearstart = 2009, yearend = 2022, time_agg = 1)
-
-
-analyze_second(filename = "looked_after", measure = "crude", time_agg = 1,
-               ind_id = 20503, year_type = "July snapshot", crude_rate = 1000)
-
+## END


### PR DESCRIPTION
Updating children looked after by local authority indicator.

Having to update the process to include a combination of data extracted from statistics.gov.scot (only goes up to 2022) and publication tables from social work statistics for 2023 and 2024.

Numerator data is available up to 2024 but rate cannot be calculated until 2024 population estimates released at council level. Script is set up though to read in and prepare 2024 data so wheoever is updated next just needs to update year_end parameter of main_analysis function when pop estimates released.


