### PR TITLE
Life expectancy indicators - renaming cols

### DIFF
--- a/Life Expectancy Indicators/3.Profiles Indicators_male & female life expectancy.R
+++ b/Life Expectancy Indicators/3.Profiles Indicators_male & female life expectancy.R
@@ -44,7 +44,10 @@ le0_iz_profiles <- le0_data %>%
          year=as.numeric(substr(time_period,1,4))+2, # year should be mid-point - this forumla assumes 5 year time period
          trend_axis=paste0(as.character(year)," Midpoint")) %>%
   select (geography,sex_grp, year, LEx,lci,uci,def_period,trend_axis) %>%
-  rename(code=geography)
+  rename(code=geography,
+         lex = LEx,
+         lowci = lci,
+         upci = uci)
 
 #close all life expectancy data - the difference in row numbers will be those areas excluded because of small numbers
 #it can be useful to know which areas were excluded if customers ask why the figure is missing


### PR DESCRIPTION
Hi Vicky, 

The IZ/locality figures are NA in the latest life expectancy shiny files. We've had a query from someone in LIST about the figures being missing from the profiles tool. I was too focused on checking CA/HB corrections and hadn't clocked the other geographies figures were missing when these were re-run - woops!

Looks like it's just because of some mismatching column names between the small geographies data and large geographies data which means when the two dfs are combined and final columns are selected, it's dropping the cols that contained the small area data.

I've re-run the script '3.Profiles Indicators_male & female life expectancy' and files are sitting their in data to be checked. If all is okay I'll move them over and re-deploy.