### PR TITLE
Ap la lookup helper function & active travel to school

### DIFF
--- a/Active travel to school.R
+++ b/Active travel to school.R
@@ -4,9 +4,13 @@
 # Data is supplied annually  Hands Up Scotland (HandsUpScotland@sustrans.org.uk) after the release of their annual publication
 # They usually sent across without having to request as it's a regular request
 
+# Note Aug 2025: We're provided data for primary and secondary schools separately.
+# Could look to develop popgroups file at next update?
+
 ### 2. Packages/dependencies ------
 source("./functions/main_analysis.R")
 source("./functions/data cleaning functions/ca_names_to_codes.R")
+library(readxl)
 
 ### 3. Clean data ------
 

--- a/Active travel to school.R
+++ b/Active travel to school.R
@@ -46,17 +46,15 @@ data <- data |>
 
 
 #Fix CA names and convert to S-codes
-data2 <- ca_names_to_codes(data, `Local Authority`)
-
-###############################################################################
+data <- ca_names_to_codes(data, `Local Authority`)
 
 # select final columns 
 data <- data |> 
-  select(ca, year, numerator, denominator)
+  select(code, year, numerator, denominator)
 
 # drop N/A rows
 data <- data |>
-  filter(if_any(c(ca, numerator, denominator), complete.cases))
+  filter(if_any(c(code, numerator, denominator), complete.cases))
 
 
 # save file to be used in analysis functions 
@@ -64,7 +62,7 @@ saveRDS(data, paste0(data_folder, "Prepared Data/active_travel_to_school_raw.rds
 
 ### 4. Run analysis functions ------
 main_analysis(filename = "active_travel_to_school", geography = "council",
-              measure = "percent", yearstart = 2008, yearend = 2023, time_agg = 1,
+              measure = "percent", yearstart = 2008, yearend = 2024, time_agg = 1,
               ind_id = 13040, year_type = "school")
 
 

--- a/functions/data cleaning functions/ca_names_to_codes.R
+++ b/functions/data cleaning functions/ca_names_to_codes.R
@@ -26,12 +26,10 @@ ca_names_to_codes <- function(df, council_area){
                                 TRUE ~ {{council_area}})) 
   
   #Read in the CA dictionary that matches names to S-codes
-  ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds")) |> 
-    rename({{council_area}} := areaname) #rename areaname col of lookup to match data passed into function
-  #ensures left_join below will work as expected. 
+  ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds")) 
   
   df2 <- left_join(df, ca_dict) |> #join df passed into function to lookup
-    select(- {{council_area}} ) #drop ca names leaving only S-codes
+    select(-areaname, -{{council_area}}) #drop ca names leaving only S-codes
   
 }
 

--- a/functions/data cleaning functions/ca_names_to_codes.R
+++ b/functions/data cleaning functions/ca_names_to_codes.R
@@ -7,7 +7,6 @@
 
 #df - the indicator dataframe that is being prepared
 #council_area - the column of the dataframe containing the names of the council areas. 
-#This argument does not need to take any particular value as the lookup will be changed to match. 
 
 ca_names_to_codes <- function(df, council_area){
   

--- a/functions/data cleaning functions/ca_names_to_codes.R
+++ b/functions/data cleaning functions/ca_names_to_codes.R
@@ -1,44 +1,40 @@
-#Could the function read in the lookup and convert names to S-codes?
+#CA Names to Codes Function
 
-library(dplyr)
-library(stringr)
+#This function takes a dataframe with a column containing the names of council areas 
+#and converts these into S-codes
 
-ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds"))
+#It also fixes common variants of council names to match what is expected by the lookup
 
-test_df <- ca_dict |> 
-  select(1) |>  #keep only LA names
-  mutate(areaname = str_replace(areaname, " and ", " & "),
-         areaname = case_when(areaname == "City of Edinburgh" ~ "Edinburgh City", #another scneario of Edinburgh, City of needed
-                              areaname == "Na h-Eileanan Siar" ~ "Eileanan Siar",
-                              areaname == "Orkney Islands" ~ "Orkney", 
-                              areaname == "Shetland Islands" ~ "Shetland",
-                              TRUE ~ areaname)) 
-
+#df - the indicator dataframe that is being prepared
+#council_area - the column of the dataframe containing the names of the council areas. 
+#This argument does not need to take any particular value as the lookup will be changed to match. 
 
 ca_names_to_codes <- function(df, council_area){
   
+  #Converting common versions of council names to match lookup
+  #This list could be amended if new variants are identified
   df <- df |> 
-    mutate(areaname = str_replace(areaname, "&", "and"),
-           areaname = case_when(areaname == "Eileanan Siar" ~ "Na h-Eileanan Siar", 
-                                areaname == "Western Isles" ~ "Na h-Eileanan Siar", 
-                                areaname == "Comhairle nan Eilean Siar" ~"Na h-Eileanan Siar",
-                                areaname == "Edinburgh City" ~ "City of Edinburgh", 
-                                areaname == "Edinburgh, City of" ~ "City of Edinburgh",
-                                areaname == "Orkney" ~ "Orkney Islands", 
-                                areaname == "Shetland" ~ "Shetland Islands",
-                                TRUE ~ areaname)) 
+    mutate({{council_area}} := str_replace({{council_area}}, "&", "and"),
+           areaname = case_when({{council_area}} == "Eileanan Siar" ~ "Na h-Eileanan Siar", 
+                                {{council_area}} == "Eilean Siar" ~ "Na h-Eileanan Siar",
+                                {{council_area}} == "Western Isles" ~ "Na h-Eileanan Siar", 
+                                {{council_area}} == "Comhairle nan Eilean Siar" ~ "Na h-Eileanan Siar",
+                                {{council_area}} == "Edinburgh City" ~ "City of Edinburgh", 
+                                {{council_area}} == "Edinburgh, City of" ~ "City of Edinburgh",
+                                {{council_area}} == "Orkney" ~ "Orkney Islands", 
+                                {{council_area}} == "Shetland" ~ "Shetland Islands",
+                                TRUE ~ {{council_area}})) 
   
-  ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds"))
+  #Read in the CA dictionary that matches names to S-codes
+  ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds")) |> 
+    rename({{council_area}} := areaname) #rename areaname col of lookup to match data passed into function
+  #ensures left_join below will work as expected. 
   
-  df2 <- left_join(df)
-  
-  
+  df2 <- left_join(df, ca_dict) |> #join df passed into function to lookup
+    select(- {{council_area}} ) #drop ca names leaving only S-codes
   
 }
 
-#Check my parsing code from neighbourhood perceptions(?) to try and add a failsafe that 
-#rename the la col to areaname if it's not already like that. 
-
-
+#End
 
 

--- a/functions/data cleaning functions/ca_names_to_codes.R
+++ b/functions/data cleaning functions/ca_names_to_codes.R
@@ -1,0 +1,44 @@
+#Could the function read in the lookup and convert names to S-codes?
+
+library(dplyr)
+library(stringr)
+
+ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds"))
+
+test_df <- ca_dict |> 
+  select(1) |>  #keep only LA names
+  mutate(areaname = str_replace(areaname, " and ", " & "),
+         areaname = case_when(areaname == "City of Edinburgh" ~ "Edinburgh City", #another scneario of Edinburgh, City of needed
+                              areaname == "Na h-Eileanan Siar" ~ "Eileanan Siar",
+                              areaname == "Orkney Islands" ~ "Orkney", 
+                              areaname == "Shetland Islands" ~ "Shetland",
+                              TRUE ~ areaname)) 
+
+
+ca_names_to_codes <- function(df, council_area){
+  
+  df <- df |> 
+    mutate(areaname = str_replace(areaname, "&", "and"),
+           areaname = case_when(areaname == "Eileanan Siar" ~ "Na h-Eileanan Siar", 
+                                areaname == "Western Isles" ~ "Na h-Eileanan Siar", 
+                                areaname == "Comhairle nan Eilean Siar" ~"Na h-Eileanan Siar",
+                                areaname == "Edinburgh City" ~ "City of Edinburgh", 
+                                areaname == "Edinburgh, City of" ~ "City of Edinburgh",
+                                areaname == "Orkney" ~ "Orkney Islands", 
+                                areaname == "Shetland" ~ "Shetland Islands",
+                                TRUE ~ areaname)) 
+  
+  ca_dict <- readRDS(file.path("/PHI_conf/ScotPHO/Profiles/Data/Lookups/Geography/CAdictionary.rds"))
+  
+  df2 <- left_join(df)
+  
+  
+  
+}
+
+#Check my parsing code from neighbourhood perceptions(?) to try and add a failsafe that 
+#rename the la col to areaname if it's not already like that. 
+
+
+
+


### PR DESCRIPTION
Adding a new helper function in that can reduce repeated code that changes common council area variants into those expected by the lookup. Incorporating into 2024 update to Active Travel to School