### PR TITLE
fix script and 2023/24 update

### DIFF
--- a/School leavers by SCQF level.R
+++ b/School leavers by SCQF level.R
@@ -1,113 +1,212 @@
-### notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Analyst notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-# this script produces data for the following 3 indicators:-
-
-# 13009 - school leavers living in most deprived quantile with 1 or more qualification at SCQF L6
+## indicators updated ----
 # 13006 - school leavers with 1 or more qualification at SCQF L4
 # 20601 - school leavers with 1 more qualification at SCQF L6
 
-# data source: https://www.gov.scot/publications/summary-statistics-attainment-initial-leaver-destinations-no-5-2023-edition/ 
-# instructions: save the latest leaver destinations excel workbook in the 'data received' folder
 
-###############################################.
-## Part 1 - Prepare data ----
-###############################################.
+## data sourced from ----
+# https://www.gov.scot/publications/summary-statistics-for-attainment-and-initial-leaver-destinations-no-7-2025-edition/documents/
 
 
-###1.a load dependencies/functions ----
+## files created ----
+# main_dataset - Y
+# deprivation_dataset - Y (for scqf 6 at scotland level only)
+# popgroups_dataset - N
 
-source("1.indicator_analysis.R") 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Dependencies -----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+source("functions/main_analysis.R")
+source("functions/deprivation_analysis.R")
+source("functions/data cleaning functions/ca_names_to_codes.R")
+library(openxlsx)
 
-library("janitor") #for row_to_names() function 
-library("stringr")#for string_replace() function
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Read data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+folder <- file.path(profiles_data_folder, "Received Data", "School leaver positive destinations")
+file <- "SSAILD+2025+supplementary+tables+L1.6+correction.xlsx"
 
-###1.b read in data ----
-
-scqf_level <- read_xlsx(paste0(data_folder, "Received Data/summary-statistics-attainment-initial-leaver-destinations-no-6-2024.xlsx"), sheet = "N2.2a_N2.2b")
-
-ca <- readRDS(paste0(lookups,"Geography/CAdictionary.rds")) #council area lookup
-
-
-###1.c clean data ----
-
-scqf_level <- scqf_level %>%
-  select(c(1, 2, 3, 4, 5, 7, 9)) %>%
-  tail(-5) %>% #remove metadata from top of spreadsheet
-  row_to_names(row_number = 1) %>% #set 1st row as column names
-  setNames(tolower(names(.))) %>%
-  mutate(`year` = str_sub(year,1,nchar(year)-3), #convert year from FY yy/yy to yyyy
-         `local authority` = str_replace(`local authority`, "Edinburgh, City of","City of Edinburgh"),
-         `local authority` = str_replace(`local authority`, "&","and"),
-         across(everything(), ~replace(., . %in% c("[c]", "[z]", "[low]", "S"), NA)), # replace suppressed figures symbols with 0
-         across(contains(c("scqf", "leaver", "year")), as.numeric)) %>% 
-  rename("denominator" = "number of leavers") %>%
-  left_join(ca, by = c("local authority" = "areaname")) %>% # join with council area lookup
-  mutate(ca = ifelse(`local authority` == "Scotland", "S00000001", code)) # assign scotland totals a geography code
+data <- read.xlsx(
+  file.path(folder, file), 
+  sheet = "N2.2a_N2.2b",
+  cols = c(1, 3:5, 7, 9)
+) |>
+  tail(-6)
 
 
-  # school leavers with 1 or more qualification at scqf level 4 ----
-scqf_4 <- scqf_level %>%
-  filter(`simd quintile [note 5]` == "Total") %>%
-  rename("numerator" = "1+ at scqf\r\nlevel 4 or better") %>%
-  select(year, ca, denominator, numerator)
+colnames(data) <- c("year", "ca_name", "quintile", "denominator", "scqf_4", "scqf_6")
 
 
-# school leavers with 1 or more qualification at scqf level 6 ----
-scqf_6 <- scqf_level %>%
-  filter(`simd quintile [note 5]` == "Total") %>%
-  rename("numerator" = "1+ at scqf\r\nlevel 6 or better") %>%
-  select(year, ca, denominator, numerator) 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Clean data -----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# add council codes
+data <- data |>
+  ca_names_to_codes(ca_name) |>
+  mutate(code = if_else(is.na(code), "S00000001", code))
+
+# format year column as starting year of the financial year
+data <- data |>
+  mutate(year = substr(year, 1, 4))
+
+# convert suppressed values to NA
+data <- data |>
+  mutate(across(everything(), ~replace(., . %in% c("[c]", "[z]", "[low]", "S"), NA))) |>
+  mutate(across(c("denominator", "scqf_4", "scqf_6"), as.numeric))
 
 
-# school leavers in most deprived quantile with 1 or more qualification at level 6
-scqf_6_depr <- scqf_level %>%#
-  filter(`simd quintile [note 5]` == "0-20% (Most Deprived)") %>%
-  rename("numerator" = "1+ at scqf\r\nlevel 6 or better") %>%
-  select(year, ca, denominator, numerator) %>%
-  # some denominators are suppressed but not the numerator
-  #so suppress numerator too in this instance as rate cannot be calculated
-  mutate(numerator = ifelse(is.na(denominator), NA, numerator))
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Identify areas to be suppressed ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# The data is published at council level with a Scotland total included
+# Some councils are suppressed for some years/splits. Therefore need to identify
+# what HSCPs and Health boards will also need suppressed to avoid calculating inaccurate figures
 
 
-
-#1.d. Save files - do some QA checks at this point ----
-saveRDS(scqf_4, file=paste0(data_folder, 'Prepared Data/school_leavers_scqf_4_raw.rds'))
-saveRDS(scqf_6, file=paste0(data_folder, 'Prepared Data/school_leavers_scqf_6_raw.rds'))
-saveRDS(scqf_6_depr, file=paste0(data_folder, 'Prepared Data/school_leavers_scqf_6_depr_raw.rds'))
-
-
-###############################################.
-## Part 2 - Run analysis functions ----
-###############################################.
+# geography lookup - for matching councils to HSCPs and health boards
+geo_lookup <- readRDS(file.path(profiles_data_folder, "Lookups", "Geography", "DataZone11_All_Geographies_Lookup.rds")) |>
+  select(c("ca2019", "hscp2019", "hb2019")) |>
+  unique()
 
 
-analyze_first(filename = "school_leavers_scqf_4", measure = "percent", 
-               yearstart = "2009", yearend = "2022", time_agg = 1, 
-               source_suppressed = TRUE, geography = "council")
+# identify councils that have been suppressed 
+ca_suppress <- data |>
+  filter(if_any(c("denominator", "scqf_4", "scqf_6"), is.na))
 
 
-analyze_first(filename = "school_leavers_scqf_6", measure = "percent", 
-              yearstart = "2009", yearend = "2022", time_agg = 1, geography = "council",
-              source_suppressed = TRUE)
-
-analyze_first(filename = "school_leavers_scqf_6_depr", measure = "percent", 
-              yearstart = "2009", yearend = "2022", time_agg = 1, geography = "council",
-              source_suppressed = TRUE)
+# identify other geographies that fall within same boundaries as suppressed CAs
+all_suppress <- geo_lookup |>
+  filter(if_any(everything(), ~ .x %in% unique(ca_suppress$code)))
 
 
 
-analyze_second(filename = "school_leavers_scqf_4", measure = "percent", 
-               time_agg = 1, ind_id = "13009",year_type = "school")
+# flag exactly what geographies need suppressed for what quintiles and time periods.
+suppress <- ca_suppress |>
+  left_join(all_suppress, by = c("code" = "ca2019")) |>
+  pivot_longer(code:hb2019, values_to = "code", names_to = NULL) |>
+  group_by(year, code, quintile) |>
+  summarise_all(sum) |>
+  ungroup()
+
+# identify suppression required for SCQF 4
+scqf_4_suppress <- suppress |>
+  select(-scqf_6) |>
+  filter(quintile == "Total") |>
+  filter(is.na(scqf_4) | is.na(denominator)) |>
+  mutate(suppress = "Y") |>
+  select(year, code, quintile, suppress)
+
+# identify suppression required for SCQF 6
+scqf_6_suppress <- suppress |>
+  select(-scqf_4) |>
+  filter(is.na(scqf_6) | is.na(denominator)) |>
+  mutate(suppress = "Y") |>
+  select(year, code, quintile, suppress)
 
 
-analyze_second(filename = "school_leavers_scqf_6", measure = "percent", 
-               time_agg = 1, ind_id = "13006",year_type = "school")
-
-
-analyze_second(filename = "school_leavers_scqf_6_depr", measure = "percent", 
-               time_agg = 1, ind_id = "20601",year_type = "school")
+# tidy up
+rm(ca_suppress, all_suppress, suppress)
 
 
 
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Aggregate to different geography levels ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+# filter out scotland totals temporarily
+scotland_data <- data |>
+  filter(code == "S00000001")
+
+# map HSCPs and HBs to council areas and add Scotland data back on
+data <- data |>
+  filter(code != "S00000001") |>
+  left_join(geo_lookup, by = c("code" = "ca2019")) |>
+  pivot_longer(cols = c("code", "hscp2019", "hb2019"), names_to = NULL, values_to = "code") |>
+  rbind(scotland_data) |>
+  group_by(code, year, quintile) |>
+  summarise_all(sum) |>
+  ungroup() 
+
+
+# scqf 4 data with suppression applied
+scqf_4 <- data |>
+  filter(quintile == "Total") |>
+  select(-scqf_6) |>
+  rename(numerator = scqf_4) |>
+  left_join(scqf_4_suppress, by = c("year", "code", "quintile")) |>
+  mutate(across(c("numerator", "denominator"), ~ if_else(is.na(suppress), .x, NA))) |>
+  select(-suppress)
+
+# scqf 6 data with suppression applied
+scqf_6 <- data |>
+  select(-scqf_4) |>
+  rename(numerator = scqf_6) |>
+  left_join(scqf_6_suppress, by = c("year", "code", "quintile")) |>
+  mutate(across(c("numerator", "denominator"), ~ if_else(is.na(suppress), .x, NA))) |>
+  select(-suppress)
+
+
+# filter on totals for scqf main file
+scqf_main <- scqf_6 |>
+  filter(quintile == "Total")
+
+# save temp files to use in analysis functions
+saveRDS(scqf_4, file.path(profiles_data_folder, "Prepared Data", "13009_scqf_4_plus_raw.rds"))
+saveRDS(scqf_6, file.path(profiles_data_folder, "Prepared Data", "13006_scqf_6_plus_raw.rds"))
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Create main indicator datasets -----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+main_analysis(filename = "13009_scqf_4_plus", measure = "percent", 
+              yearstart = "2012", yearend = "2023", time_agg = 1, 
+              geography = "multiple", ind_id = 13009, year_type = "school")
+
+main_analysis(filename = "13006_scqf_6_plus", measure = "percent", 
+              yearstart = "2012", yearend = "2023", time_agg = 1, 
+              geography = "multiple", ind_id = 13009, year_type = "school")
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Create deprivation dataset ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# only doing for scotland level just now
+# due to error when trying to calculate inequality measures for HB/CA level
+# revisit to work out why happening
+
+scqf_6_depr <- scqf_6 |>
+  filter(grepl(pattern = "S00", code)) |>
+  mutate(quint_type = "sc_quin") |>
+  mutate(quintile = case_when(quintile == "0-20% (Most Deprived)" ~ "1",
+                              quintile == "20-40%" ~ "2",
+                              quintile == "40-60%" ~ "3",
+                              quintile == "60-80%" ~ "4",
+                              quintile == "80-100% (Least Deprived)"  ~ "5",
+                              TRUE ~ "Total")) |>
+  calculate_percent()|>
+  calculate_inequality_measures() |>
+  mutate(year = as.numeric(year)) |>
+  create_def_period_column(year_type = "financial", agg = 1) |>
+  create_trend_axis_column(year_type = "financial", agg = 1) |>
+  mutate(ind_id = 13006) |>
+  select(-c(overall_rate, total_pop, proportion_pop, most_rate, 
+            least_rate, par_rr, count))
+
+
+# save final depr file in data to be checked folder
+saveRDS(scqf_6_depr, file.path(profiles_data_folder, "Data to be checked", "13006_scqf_6_plus_ineq.rds"))
+
+# QA file
+run_qa(filename = "13006_scqf_6_plus", type = "deprivation")
+
+## END


### PR DESCRIPTION
Hi Abbie, 

Updated script for the following 2 indicators:

- School leavers with 1 or more qualification at SCQF Level 4
- School leavers with 1 or more qualification at SCQF Level 6

There used to be a 3rd indicator called 'School leavers living in the most deprived quintile with 1 or more qualification at SCQF Level 6'. I've made it inactive in the techdoc as I'm now producing a deprivation file for both indicators so a separate indicator no longer required. The deprivation split is only at Scotland level for now and there's too many suppressed values at HB/CA level.

Updating the script for the 2 school leavers with qualifications indicators. There used to be an indicator called 'school leavers a