### PR TITLE
Mm access deprived

### DIFF
--- a/Access deprived.R
+++ b/Access deprived.R
@@ -1,164 +1,218 @@
-# ScotPHO indicators: people living in 15% most access deprived areas
+# ~~~~~~~~~~~~~~~~~~~~~~
+# Analyst notes -----
+# ~~~~~~~~~~~~~~~~~~~~~~
 
-# Part 1 - Create population files
-# Part 2 - Create access rank data and save basefiles
-# Part 3 - Calling the analysis functions 
+# This script updates the following indicator:
+# Population living in the 15% most access deprived datazones in Scotland
 
-###############################################.
-## Packages/Filepaths/Functions ----
-###############################################.
-# Varies filepaths depending on if using server or not.
-if (sessionInfo()$platform %in% c("x86_64-redhat-linux-gnu (64-bit)", "x86_64-pc-linux-gnu (64-bit)")) {
-  cl_out_depr <- "/conf/linkage/output/lookups/Unicode/Deprivation/"
-} else {
-  cl_out_depr <- "//stats/linkage/output/lookups/Unicode/Deprivation/"
-}
+# We apply population weighting i.e. ranking the DZs according to their access 
+# deprivation score alongside a cumulative total of DZ populations. 
+# The cut-off for the most deprived DZs is the point at which 15% of the population has been included.
+# For a more thorough explanation of methodology, refer to the metadata in the techdoc.
 
-source("1.indicator_analysis.R") #Normal indicator functions
-source("2.deprivation_analysis.R") # deprivation function
+# Each year when updating this indicator, the 'simd_list' below needs reviewed to 
+# ensure there is a version of SIMD assigned to the year you are trying to update. 
+# If there are no new versions of SIMD (they're only released every few years), 
+# then simply extend the period in 'trends_from' for the most recent version of SIMD.
 
-#Small function to standarize each years info. Function parameters:
-#Data is for what basefile to use, list_pos is for the position of the data frame
-#simd for which simd variables-year to look at, year for what year is the data created.
-read_simd <- function(data, simd, year, list_pos) {
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# Dependencies ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+source("functions/main_analysis.R")
+library(phslookups) # for get_simd_datazone() function to read in SIMD versions from cl-out
+
+# uncomment and run below to install phslookups package:
+# remotes::install_github("Public-Health-Scotland/phslookups")
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~
+# SIMD versions ----
+# ~~~~~~~~~~~~~~~~~~~~~~~
+
+# Details about each version of SIMD - matches Table 4 of PHS deprivation guidance:
+# https://publichealthscotland.scot/media/24056/2023-12-phs-deprivation-guidance-v35.pdf
+
+# dz_year = whether datazones are 2001/2011 based
+# pop_year = year of population used in the index
+# trend_years = period each version of SIMD should be applied to
+
+simd_info <- list(
+  # SIMD 2004 pop_year should be 2001 but our pop lookups only start at 2002
+  "2004" = list(dz_year = "2001", pop_year = 2002, trend_years = 2002:2003),
+  "2006" = list(dz_year = "2001", pop_year = 2004, trend_years =  2004:2006),
+  "2009v2" = list(dz_year = "2001", pop_year = 2007, trend_years = 2007:2009),
+  "2012" = list(dz_year = "2001", pop_year = 2010, trend_years = 2010:2013),
+  "2016" = list(dz_year = "2011", pop_year = 2014, trend_years = 2014:2016),
+  "2020v2" = list(dz_year = "2011", pop_year = 2017, trend_years = 2017:2023)
+)
+
+
+# The purrr::imap() function is used to iterate over this list and prepare
+# data for SIMD version. When using this function:
+# '.y' refers to the name of the simd version e.g. "2004"
+# '.x' refers to an element in the list for that particular simd version e.g. dz_year
+
+# e.g. when .y is "2020v2":
+# .x$pop_year = 2017
+# .x$dz_year = 2011
+# .x$trends_years = 2017:2023
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Get population estimates data ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Early versions of SIMD are based on 2001 DZs and more recent versions are based on 2011 DZs
+# Therefore use pop estimates based on both 2001 and 2011 DZs for different years of this indicators time series
+pop_data <- list("2001" = "DZ01_pop_basefile.rds", 
+                 "2011" = "DZ11_pop_basefile.rds")
+
+
+# read in 2 x pop data files and aggregate estimates for each year and datazone
+pop_data <- map(pop_data, ~ 
+                  readRDS(file.path(profiles_data_folder, "Lookups", "Population", .x)) |>
+                  group_by(across(contains("datazone")), year) |>
+                  summarise(pop = sum(denominator), .groups = "drop") |>
+                  rename(datazone = 1))
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Find most deprived datazones -----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# For each SIMD version, get pop estimates for the year that SIMD is based on 
+# e.g. for SIMD2020v2, take 2011 pop estimates and filter on 2017
+simd_pop_index <- imap(simd_info, ~ {
+  pop_data[[.x$dz_year]] |>
+    filter(year == .x$pop_year)
+})
+
+
+# Calculate 15% of the population for the year each SIMD is based on
+pop_15 <- map(simd_pop_index, ~ sum(.x$pop) * 0.15)
+
+
+
+# For each SIMD, read in the lookup from cl-out and select access domain rank and any geography cols
+# Note versions of SIMD that are DZ01 based won't have an intzone2011 col
+# This means indicator time series will only include IZ/locality trends from 2017 onwards
+simd_data <- imap(simd_info, ~ {
   
-  datazone <- tolower(substr(data,1,12))
+  # name of domain col e.g. "simd2020v2_access_rank"
+  domain_col <- paste0("simd", .y, "_access_rank")
   
-  data_simd <- readRDS(paste0(cl_out_depr, data, '.rds')) %>% 
-    setNames(tolower(names(.))) %>%   #variables to lower case
-    select({{simd}}, datazone) %>% 
-    rename(rank = {{simd}}, datazone = datazone) %>% 
-    mutate(year = year)
+  phslookups::get_simd_datazone(simd_version = .y) |>
+    select(
+      datazone = 1,
+      rank = {{domain_col}},
+      any_of(c(
+        "ca2019" = matches("^CA2019$", ignore.case = TRUE),
+        "hscp2019" = matches("^HSCP2019$", ignore.case = TRUE),
+        "intzone2011" = matches("^intzone2011$", ignore.case = TRUE)
+      ))
+    )
+})
+
+
+
+# For each SIMD, join with pop index year data and arrange dzs from most (no 1) to least access deprived
+# calculate a cumulative total of the population - when 15% of pop is reached, label DZs as 'most deprived'
+simd_data <- imap(simd_info, ~ {
   
-  data_access[[list_pos]] <<- data_simd #assigning to list
-}
-
-###############################################.
-## Part 1 - Create population files ----
-###############################################.
-# Creating base populations using dz2001 before 2014 and dz2011 onwards
-#This is better to be run in R server.
-dz01_base <- readRDS(paste0(data_folder, "Lookups/Population/DZ01_pop_basefile.rds")) %>% 
-  filter(year<2014) %>% # 2014 uses simd2016 based on dz2011
-  rename(datazone = datazone2001)
-
-dz11_base <- readRDS(paste0(data_folder, "Lookups/Population/DZ11_pop_basefile.rds")) %>% 
-  subset(year>2013) %>% # 2014 onwards uses simd based on dz2011
-  rename(datazone = datazone2011)
-
-dz_pop_base <- rbind(dz01_base, dz11_base)
-rm(dz01_base, dz11_base)  
-
-# This creates a file with the number of population that represents Scotland's 15%
-scot_pop_base <- dz_pop_base %>% group_by(year) %>% 
-  mutate(pop_15 = denominator/20*3) %>%  # creating 15% population 
-  summarise(pop_15 = sum(pop_15)) #obtaining total pop
-
-# Data set with the population for each datazone
-dz_pop_base <- dz_pop_base %>% group_by(year, datazone) %>% 
-  summarise(pop = sum(denominator)) #obtaining total pop for each datazone
-
-###############################################.
-## Part 2 - Create access rank data ----
-###############################################.
-data_access <- list() #creating empty list for placing data created by function
-
-# The function creates the dataset with the rank for each datazone and assigns it to the list
-mapply(read_simd, data = "DataZone2001_all_simd", simd = "simd2004_access_rank", 
-       year = 2002:2003, list_pos = 1:2) #simd version 2004
-mapply(read_simd, data = "DataZone2001_all_simd", simd = "simd2006_access_rank", 
-       year = 2004:2006, list_pos = 3:5) #simd version 2006
-mapply(read_simd, data = "DataZone2001_all_simd", simd = "simd2009v2_access_rank", 
-       year = 2007:2009, list_pos = 6:8) #simd version 2009
-mapply(read_simd, data = "DataZone2001_all_simd", simd = "simd2012_access_rank", 
-       year = 2010:2013, list_pos = 9:12) #simd version 2012
-mapply(read_simd, data = "DataZone2011_simd2016", simd = "simd2016_access_rank", 
-       year = 2014:2016, list_pos = 13:15) #simd version 2016
-mapply(read_simd, data = "DataZone2011_simd2020v2", simd = "simd2020v2_access_rank", 
-       year = 2017:2019, list_pos = 16:18) #simd version 2020
-
-data_access <- do.call("rbind", data_access) # converting from list into dataframe
-
-# Joining with both of the populations: dz and scotland 15%
-data_access <- left_join(data_access, dz_pop_base, by = c("datazone", "year"))
-data_access <- left_join(data_access, scot_pop_base, by = "year")
-
-rm(dz_pop_base)
-
-# Creating cumulative populations for each year based on access rank
-data_access %<>% group_by(year) %>% arrange(rank) %>% 
-  mutate(cum_pop = cumsum(pop)) %>% ungroup() %>% 
-  mutate_if(is.integer, as.numeric) %>% #R complaining of different variable types
-  # If the datazone is included in the 15% more access deprived then use its
-  # population as numerator, if not consider 0
-  mutate(numerator = case_when((pop_15 - cum_pop)>=0 ~ pop,
-                                TRUE ~ 0)) %>% 
-  select(datazone, year, numerator)
-
-#File for deprivation analysis
-saveRDS(data_access, file = paste0(data_folder, "Prepared Data/access_deprived_depr_raw.rds"))
-
-#File for DZ11 for 2014 onwards
-data_access_dz11 <- data_access %>% filter(year>2013)
-
-saveRDS(data_access_dz11, file = paste0(data_folder, "Prepared Data/access_deprived_dz11_raw.rds"))
-
-#Preparing file for CA for period 2004 to 2013
-data_access_dz01 <- data_access %>% filter(year<2014)
-#Lookup file for CA
-ca_lookup <- read_xlsx(paste0(data_folder, "Lookups/Geography/DataZone2001.xlsx")) %>% 
-  setNames(tolower(names(.))) %>% select(ca, datazone)
-
-#Merging with lookup and aggregating by ca
-data_access_dz01 <- left_join(data_access_dz01, ca_lookup) %>% 
-  group_by(ca, year) %>% 
-  summarise(numerator=sum(numerator, na.rm = T)) %>% ungroup() %>% 
-  #Dealing with changes in ca codes. Transforms old code versions into 2019 ones
-  mutate(ca = recode(ca, "S12000015"='S12000047', "S12000024"='S12000048', 
-                     "S12000046"='S12000049', "S12000044"='S12000050'))
-
-saveRDS(data_access_dz01, file = paste0(data_folder, "Prepared Data/access_deprived_ca_raw.rds"))
-
-###############################################.
-## Part 2 - Calling the analysis functions ----
-###############################################.
-#Normal indicator analysis, first for CA and then DZ11
-analyze_first(filename = "access_deprived_ca", geography = "council", measure = "percent", hscp = T,
-              yearstart = 2002, yearend = 2013, time_agg = 1, pop = "CA_pop_allages")
-analyze_first(filename = "access_deprived_dz11", geography = "datazone11", measure = "percent", 
-              yearstart = 2014, yearend = 2019, time_agg = 1, pop = "DZ11_pop_allages")
-
-#Merging CA and DZ11 together
-all_data <- rbind(readRDS(paste0(data_folder, "Temporary/access_deprived_dz11_formatted.rds")),
-                  readRDS(paste0(data_folder, "Temporary/access_deprived_ca_formatted.rds")))
-saveRDS(all_data, file = paste0(data_folder, "Temporary/access_deprived_all_formatted.rds"))
-
-#Calling second analysis function
-analyze_second(filename = "access_deprived_all", measure = "percent", 
-               time_agg = 1, ind_id = 20902, year_type = "calendar")
-
-###### Save final result before it is overwritten by analyze_deprivation() and filter correct years to include in Plot
-data_shiny_filtered <- final_result %>% 
-  select(c(code, ind_id, year, numerator, rate, lowci, upci, def_period, trend_axis)) %>% 
-  filter(year %in% c(2002, 2004, 2007, 2010, 2014, 2017)) %>% 
-  arrange(code, year, trend_axis)
-
-###############################################.
-#Deprivation analysis function
-analyze_deprivation(filename="access_deprived_depr", measure="percent", time_agg=1, 
-                    yearstart= 2002, yearend=2019,  
-                    year_type = "calendar", pop = "depr_pop_allages", ind_id = 20902)
-
-####### Filter depirvation data to include correct years
-data_shiny_deprivation_filtered <- final_result %>%  
-  filter(year %in% c(2002, 2004, 2007, 2010, 2014, 2017)) %>% 
-  arrange(code, year, trend_axis)
+  simd_data[[.y]] |>
+    left_join(simd_pop_index[[.y]], by = "datazone") |>
+    arrange(rank) |>
+    mutate(cumsum = cumsum(pop)) |>
+    mutate(depr_status = if_else(cumsum <= pop_15[[.y]], "15% most deprived", "85% least deprived")) |>
+    select(any_of(c("datazone", "intzone2011", "ca2019", "hscp2019", "rank", "depr_status")))
+})
 
 
-# Save to Data to be checked folder
 
-saveRDS(data_shiny_filtered, file = paste0("/PHI_conf/ScotPHO/Profiles/Data/", "Data to be checked/", "access_deprived_all", "_shiny.rds"))
-write_csv(data_shiny_filtered, file = paste0("/PHI_conf/ScotPHO/Profiles/Data/", "Data to be checked/", "access_deprived_all", "_shiny.csv"))
-saveRDS(data_shiny_deprivation_filtered, file = paste0("/PHI_conf/ScotPHO/Profiles/Data/", "Data to be checked/", "access_deprived_depr_ineq.rds"))
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Create trend data -----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ 
+
+
+# For each SIMD, filter population data for the 
+# years applicable to that version and join with SIMD lookup
+# e.g. for SIMD2020v2, take DZ11 pop estimates and filter on years 2017-2023
+# and join with SIMD2020v2 to get deprivation status for each dz/year
+pop_data <- imap(simd_info, ~ {
+  pop_data[[.x$dz]] |>
+    filter(year %in% .x$trend_years) |>
+    left_join(simd_data[[.y]], by = "datazone")
+})
+
+
+# unlist into single df
+result <- bind_rows(pop_data) |>
+  arrange(year) |>
+  mutate(scotland = "S00000001")
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Aggregate to different geography levels -----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
+# add HSCP localities in - these are not an official geography
+# with set of standard codes so are not part of any of the SIMD lookups
+localities <- readRDS(file.path(profiles_data_folder, "Lookups", "Geography", "DataZone11_HSCLocality_Lookup.rds")) |>
+  select(datazone2011, hscp_locality)
+
+result <- result |>
+  left_join(localities, by = c("datazone" = "datazone2011"))
+
+
+# aggregate by geography level and remove IZ/locality data pre-2017
+result <- result |>
+  select(-datazone) |>
+  pivot_longer(
+    cols = -c(pop, year, depr_status, rank), 
+    names_to = "geo_level", 
+    values_to = "code"
+  ) |>
+  filter(!is.na(code)) |>
+  group_by(year, code, depr_status) |>
+  summarise(denominator = sum(pop), .groups = "drop")
+
+
+
+# create numerator and denominator data 
+result <- result |>
+  mutate(numerator = if_else(depr_status == "15% most deprived", denominator, 0)) |>
+  select(-depr_status) |>
+  group_by(year, code) |>
+  summarise_all(sum) |>
+  ungroup()
+
+
+# save temp file for analysis function 
+saveRDS(result, file.path(profiles_data_folder, "Prepared Data", "20902_pop_access_deprived_raw.rds"))
+
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Run analysis function ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# A few points when looking at QA results:
+
+# 1. Results should confirm that IZ/locality data only available for 2014 onwards
+
+# 2. Scotland trend will always be around 15% since the 15% most deprived areas hold approx 15% of the scottish pop 
+# (although rate may rise slightly in between pop index years before resetting again).
+
+# 3.IZ/locality trends may produce odd looking trends - this is to be expected e.g. where an IZ is comprised of a small
+# number of DZs where they may fall within the 15% most deprived in one version of SIMD but not another.
+
+main_analysis(ind_id = 20902, filename = "20902_pop_access_deprived", measure = "percent", 
+              geography = "multiple", year_type = "calendar", time_agg = 1, yearstart = 2002, yearend = 2023)
+
 
 ## END

--- a/Access deprived.R
+++ b/Access deprived.R
@@ -98,7 +98,7 @@ pop_15 <- map(simd_pop_index, ~ sum(.x$pop) * 0.15)
 
 # For each SIMD, read in the lookup from cl-out and select access domain rank and any geography cols
 # Note versions of SIMD that are DZ01 based won't have an intzone2011 col
-# This means indicator time series will only include IZ/locality trends from 2017 onwards
+# This means indicator time series will only include IZ/locality trends from 2014 onwards
 simd_data <- imap(simd_info, ~ {
   
   # name of domain col e.g. "simd2020v2_access_rank"


### PR DESCRIPTION
Reworking the script for the '15% most access deprived datazones' indicator to make the methodology clearer and hopefully easy to update annually. If this makes sense I can apply to the 3 x young people access/income/crime deprived as they currently only have trends from 2014 onwards using 2 SIMD versions.