### PR TITLE
fixing main analysis function

### DIFF
--- a/functions/main_analysis.R
+++ b/functions/main_analysis.R
@@ -327,7 +327,7 @@ main_analysis <- function(filename,
     # full_join selected as a fail safe to try and prevent cases where either events in areas where apparently no population (which might indicate a problem with population lookup)
     # or to keep an eye on areas with population but apparently no events, this might be legitimate for events that are rare or it might signify incomplete event/case data.
     
-    #should this be full or left - based on which?
+    #should this be full or left - based on population lookup?
     data <- full_join(x = data, y = pop_lookup, by = joining_vars) 
 
     # check year parameters are sensible and all required years are present


### PR DESCRIPTION
As it stands the main function could spew out incorrect rates for some geographies if you have an indicator where not every age group is present in each year of a rolling average (it probably only affects standardised rates and more likely smaller geographies). Reverting to the sum (rather than hablar sum_) and recoding NA to zeros ensures these missing cases are handled properly.
An alternative way to fix might be to change the join at line 331 from a full join to a left join but i'm not sure that would fool proof either?  
Sorry looking at this has me very confused so feel free to give me a call if its easier to chat about.
The indicator I rand to check this was suicides in 16+, basically I checked that the denominator for council areas that make up a single NHS board now agree. 
