### PR TITLE
ER - SHeS updates: adding PA profile indicators 

### DIFF
--- a/4.Data Quality Checks_inequalities indicators.Rmd
+++ b/4.Data Quality Checks_inequalities indicators.Rmd
@@ -70,7 +70,7 @@ if(file.exists(old_indicator_filepath)) {
 Indicator:  **`r filename`** <br>
 Date:  **`r format(Sys.time(), '%d %B, %Y %H:%M')`** <br>
 
-**New** indicator file:  /`r (paste0(output_folder,"/", filename, ".rds"))`<br>
+**New** indicator file:  /`r (paste0(output_folder,"/", filename, "_ineq.rds"))`<br>
 **Old** indicator file (for comparisons):  /`r (paste0(old_indicator_filepath))` <br>
 
 ------------------------------------------------------------------------------------

--- a/National Performance Framework.R
+++ b/National Performance Framework.R
@@ -1,24 +1,16 @@
+## NPF data not updated since 2024.
+## More up-to-date versions of most indicators now produced in other scripts
+## Persistent poverty now produced in Persistent poverty.R
+## Indicators 99117 (Young peoples mental wellbeing) and 99121 (Health risk behaviours) produced in Scottish Health Survey.R
+
 #new indicators introduced for Population health Framework/care and wellbeing portfolio
 
-###################################################################################################################################################################
-####### JUNE 2025: ##########
-####### NB. Persistent poverty now produced in a separate script (Persistent poverty.R), as more recent data are available from a different source. ###############
-###################################################################################################################################################################
-
-
 ##  This script will update indicators: 
-#   99121: Health risk behaviours
 #   99123: Gender balance in organisations (for minority ethnic population)
 
-#   Indicator 99117 (Young peoples mental wellbeing) was previously produced here, but as this is sourced from the SHeS, and hasn't been updated in the NPF data file, we're
-#   now producing it with other SHeS indicators: starting with extraction of the microdata in the ScotPHO_survey_data repo, and then finishing the processing in this repo.
 
 # Data source is the National Performance Framework open data on statistics.gov.scot
 # 2024 update (August 2024): https://statistics.gov.scot/downloads/file?id=ca23e4da-4aa2-49e7-96e2-38f227f9d0de%2FALL+NPF+INDICATORS+-+2024+-+statistics.gov.scot+NPF+database+excel+file+-+August+2024.xlsx
-# (N.B. THERE ARE OTHER SCOTPHO INDICATORS IN THIS FILE THAT COULD BE USED TO DE-DUPLICATE OTHER SCRIPTS. NOT READ IN CURRENTLY.)
-# (N.B.2 THE DATA AREN'T CONSISTENTLY PRESENTED IN THIS FILE, SO ADD NEW INDICATORS WITH CARE)
-
-
 
 ### Functions/packages ----
 source("functions/main_analysis.R") # for packages and QA
@@ -66,33 +58,13 @@ data <- dat %>%
   clean_names() %>% 
   
   # Select relevant indicators 
-  filter(indicator %in% c("Persistent poverty", 
-                          "Health risk behaviours",
+  filter(indicator %in% c( 
                           "Gender balance in organisations",
                         # Sourced from elsewhere now:  
                           # "Child material deprivation", "Children's material deprivation", # now source direct from stats.gov (see Child Poverty.R script) as more disaggregated there
                           # "Child Wellbeing and Happiness", #NPF name for young peoples mental wellbeing indicator
-                        # Additional CWB indicators available:
-                          "Access to green and blue space",
-                          "Healthy Start", #perinatal mort
-                          "Employees on the Living wage", "Employees on the living wage",
-                          "Places to interact",
-                          "Satisfaction with housing", "Satisfaction with Housing",
-                          "Quality of public services",
-                          "Visits to the outdoors", "Visits to the Outdoors",
-                          "Work place learning",
-                          "Contractually secure work"
-                        # Other ScotPHO/CWB indicators that could be read in from this file:
-                          # "Educational attainment 7", # school leaver attainment (other educ attainment vars too)
-                          # "Child social and physical development",
-                          # "Food Insecurity",
-                          # "Healthy life expectancy - Female",                         
-                          # "Healthy life expectancy - Male",
-                          # "Healthy life expectancy: Females",                         
-                          # "Healthy life expectancy: Males",
-                          # "Healthy weight - Adult",
-                          # "Influence over local decisions", "Loneliness", "Mental wellbeing", "Pay gap", 
-                          # "Perceptions of local area", "Physical activity", "Premature mortality", "Unmanageable debt", "Young peoples participation"
+                          # "Health risk behaviours",
+                          # "Persistent poverty"
                       )) %>%
 
   # Convert indicator names to lower case and add underscore 
@@ -170,7 +142,7 @@ data <- dat %>%
   
   # Add indicator ids
   mutate(ind_id = case_when(#indicator == "persistent_poverty" ~ 99116, # subsequently split out child poverty into ind_id 30155
-                            indicator == "health_risk_behaviours" ~ 99121,
+                            #indicator == "health_risk_behaviours" ~ 99121,
                             indicator == "gender_balance_in_organisations" ~ 99123
                             # Uncomment once these CWB indicators have IDs and are added to techdoc (will be NA currently):
                             # indicator == "contractually_secure_work" ~ xxxxx,
@@ -365,9 +337,6 @@ prepare_final_files <- function(ind, agerange=NULL){
 # Create final files and run QA reports ----
 
 
-# Indicator  99121: Health risk behaviours ----
-prepare_final_files(ind = "health_risk_behaviours", agerange="16+")
-
 # Indicator 99123: Gender balance in organisations (for minority ethnic population)
 prepare_final_files(ind = "gender_balance_in_organisations", agerange="16+")
 
@@ -376,13 +345,10 @@ prepare_final_files(ind = "gender_balance_in_organisations", agerange="16+")
 
 
 ###  Run QA reports ----
-run_qa(type = "main", filename = "health_risk_behaviours", test_file = FALSE)
 run_qa(type = "main", filename = "gender_balance_in_organisations", test_file = FALSE)
 
-run_qa(type = "deprivation", filename = "health_risk_behaviours", test_file = FALSE)
 run_qa(type = "deprivation", filename = "gender_balance_in_organisations", test_file = FALSE)
  
-run_qa(type = "popgrp", filename = "health_risk_behaviours", test_file = FALSE)
 run_qa(type = "popgrp", filename = "gender_balance_in_organisations", test_file = FALSE)
 
 

--- a/National Performance Framework.R
+++ b/National Performance Framework.R
@@ -1,7 +1,12 @@
-## NPF data not updated since 2024.
-## More up-to-date versions of most indicators now produced in other scripts
-## Persistent poverty now produced in Persistent poverty.R
-## Indicators 99117 (Young peoples mental wellbeing) and 99121 (Health risk behaviours) produced in Scottish Health Survey.R
+## NB. NPF data not updated since 2024.
+## More up-to-date versions of all but the gender balance indicator are now produced in other scripts
+## Persistent poverty now produced in Poverty (persistent).R
+## Child combined low income and material deprivation now produced in Poverty (all but persistent).R
+## Scottish Health Survey.R now produces:
+## 99117 (Young peoples mental wellbeing) 
+## 99121 (Health risk behaviours) 
+## 99105 Food insecurity
+## 99106 Adult healthy weight 
 
 #new indicators introduced for Population health Framework/care and wellbeing portfolio
 
@@ -61,7 +66,7 @@ data <- dat %>%
   filter(indicator %in% c( 
                           "Gender balance in organisations",
                         # Sourced from elsewhere now:  
-                          # "Child material deprivation", "Children's material deprivation", # now source direct from stats.gov (see Child Poverty.R script) as more disaggregated there
+                          # "Child material deprivation", "Children's material deprivation", 
                           # "Child Wellbeing and Happiness", #NPF name for young peoples mental wellbeing indicator
                           # "Health risk behaviours",
                           # "Persistent poverty"

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -1,13 +1,13 @@
 # TO DO:
 # look at other indicators that could be sourced from SHeS bulk data in this script.
-# Once Phys Activity profile ready to be published the commented out lines about ind 88888 (meets MVPA recs) can be run to produce this indicator.
+# look at whether the data published for the mus_rec PA indicator  on the SHeS dashboard should be used where available
 
 #########################################################
 # Scottish Health Survey data import
 #########################################################
 
 
-### Update ScotPHO indicators that can be sourced from published Scottish Health Survey data: 
+### Update the 13 ScotPHO indicators that can be sourced from published Scottish Health Survey data: 
 
 ### Care and Wellbeing indicators: 
 #   99105: Food insecurity
@@ -26,11 +26,12 @@
 #   4171: Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here) 
 #   4172: Alcohol consumption (mean weekly units)"
 ### Physical activity profile:
-#   88888:  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" N.B. INDICATOR NOT PUBLISHED YET: PUT IN TECHDOC WHEN READY TO PUBLISH.
+#   14001:  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" N.B. INDICATOR NOT PUBLISHED YET: PUT IN TECHDOC WHEN READY TO PUBLISH.
 
-### And adding data for a further 21 indicators (12 adult mental health, 9 CYP mental health) that have been processed in the ScotPHO_survey_data repo 
+### And adding data for a further 24 indicators (13 adult, 11 CYP) that have been processed in the ScotPHO_survey_data repo 
 ### (raw data processing elsewhere because they use UK Data Service data)
 ### (data for SIMD x sex are also added for the 6 published variables above that are in the adult MH profile (see *), as these can be derived from the UKDS data.)
+### (NB mus_rec (Adults meeting muscle strengthening guidelines) is also published in the open data: look at whether the published data should be used where available)
 
 # Adult:
 # 30002 = life_sat	Mean score on the question "All things considered, how satisfied are you with your life as a whole nowadays?" (variable LifeSat).  N.B. This indicator is also available from the ScotPHO Online Profiles (national and council area level, but not by SIMD). Life satisfaction is measured by asking participants to rate, on a scale of 0 to 10, how satisfied they are with their life in general. On the scale, 0 represented 'extremely dissatisfied' and 10 'extremely satisfied' (the intervening scale points were numbered but not labelled). 
@@ -45,6 +46,7 @@
 # 30053 = contrl	Percentage of adults who often or always have a choice in deciding how they do their work, in their current main job. The five possible responses ranged from "always" to "never". The variable was Contrl. 
 # 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
 # 30026 = rg17a_new	Percentage of adults who provide 20 or more hours of care per week to a member of their household or to someone not living with them, excluding help provided in the course of employment. Participants were asked whether they look after, or give any regular help or support to, family members, friends, neighbours or others because of a long-term physical condition, mental ill-health or disability; or problems related to old age. Caring which is done as part of any paid employment is not asked about. From 2014 onwards, this question explicitly instructed respondents to exclude caring as part of paid employment. The variables used to construc this indicator were RG15aNew (Do you provide any regular help or care for any sick, disabled, or frail people?) and RG17aNew (How many hours do you spend each week providing help or unpaid care for him/her/them?). 
+# 14002 - adt10gp_tw_LOW - Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
 
 # CYP:
 # 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
@@ -55,7 +57,16 @@
 # 30173	Conduct problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the conduct problems scale of the Strengths and Difficulties Questionnaire (SDQ)
 # 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
 # 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
+# 14003 - c00sum7s - Children with very low activity levels
+# 14006 - spt1ch - Children participating in sport
+# 14007 - ch30plyg - Children engaging in active play
 
+# NB. These indicators won't be produced until the PA profile is ready to be published:
+# 14001 - mus_rec - Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
+# 14002 - adt10gp_tw_LOW - Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
+# 14003 - c00sum7s - Children with very low activity levels
+# 14006 - spt1ch - Children participating in sport
+# 14007 - ch30plyg - Children engaging in active play
 
 # The published data are downloaded from statistics.gov.scot:
 # https://statistics.gov.scot/data/search?search=scottish+health+survey
@@ -109,7 +120,7 @@ SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Sco
 
 # Pre-processed UKDS data (UK data service)
 # The data read in below is prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# Last updated Jan 2026 (SHeS data up to 2022)
+# Last updated Jan 2026 (SHeS data up to 2023)
 shes_from_ukds <- readRDS(paste0(profiles_data_folder, "/Prepared Data/shes_raw.rds")) %>%
   mutate(code = as.character(code))
 
@@ -186,7 +197,7 @@ keep <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 un
           "Food insecurity (worried would run out of food): Yes",  # 99105                                                                        
           "Healthy weight: Healthy weight", #99106                                                                                              
           "Summary activity levels: Meets recommendations",  #99107 
-        #  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations", #88888 #NOT PUBLISHED YET
+        #  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations", #14001 #NOT PUBLISHED YET
           "Self-assessed general health: Very good/Good",    # 99108                                                                             
           "Fruit & vegetable consumption: 5 portions or more",  #30013                                                                          
           "Mental wellbeing", # 30001 (mean score, as in the indicator definition)                                                                                                           
@@ -229,7 +240,7 @@ shes_df <- shes_df %>%
                             indicator == "common_mh_probs" ~ 30003, 
                             indicator == "mental_wellbeing" ~ 30001, 
                             indicator == "physical_activity" ~ 99107,
-                        #    indicator == "meets_mvpa_and_strength_recs" ~ 88888,
+                        #    indicator == "meets_mvpa_and_strength_recs" ~ 14001,
                             indicator == "binge_drinking" ~ 4170,
                             indicator == "problem_drinker" ~ 4171,
                             indicator == "weekly_alc_units" ~ 4172)) %>% 
@@ -262,18 +273,26 @@ shes_df <- shes_df %>%
 
 ###------------------------------------------------------------------------------------------------
 ### Now add the UKDS data:
+# (and standardise the split_names and split_values)
 shes_df <- shes_from_ukds %>%
-  rbind(shes_df)
+  rbind(shes_df) %>%
+  mutate(split_name=case_when(split_name=="Age" ~ "Age group",
+                              split_name=="Long-term Illness" ~ "Long-term illness",
+                              TRUE ~ split_name)) %>%
+  # published data refers to long term 'conditions' but the this is used interchangeably with 'illness' in the reporting. Here we standardise these:
+  mutate(split_value=case_when(split_value %in% c("No long-term conditions", "No Long-term Illness") ~ "No long-term illness",
+                               split_value %in% c("Non-limiting long-term conditions", "Limiting Long-term Illness") ~ "Limiting long-term illness",
+                               split_value %in% c("Limiting long-term conditions", "Non-limiting Long-term Illness") ~ "Non-limiting long-term illness",
+                               TRUE ~ split_value))
 
-table(shes_df$ind_id, useNA="always") # 33 in total, no NA
-table(shes_df$indicator, useNA="always") # 33 in total, no NA
+table(shes_df$ind_id, useNA="always") # 37 in total, no NA
+table(shes_df$indicator, useNA="always") # 37 in total, no NA
 table(shes_df$code, useNA="always") # Scot, HB, LA, no NA
 table(shes_df$trend_axis, useNA="always") # 2008 to 2023, single year and 4-y aggregates, no NA
 table(shes_df$def_period, useNA="always") # 2008 to 2023, single year and 4-y aggregates, no NA
 table(shes_df$sex, useNA="always") # M/F/total, no NA
 table(shes_df$split_name, useNA="always") # 5 different splits, no NA
 table(shes_df$split_value, useNA="always") # correct, no NA
-
 
 
 
@@ -304,11 +323,17 @@ indicators_w_lower_geogs <- availability %>%
   unique()
 indicators_w_lower_geogs <- as.vector(indicators_w_lower_geogs$indicator)
 
-# which splits are available for single and aggregated years? Want to select single years for these...
-splits_w_single_and_aggd_years <- availability %>%
-  filter(count==2) %>%
-  select(indicator, geog, split_name) %>%
-  unique()
+
+### TEMPORARY STEP: drop the indicators we're not publishing yet: the PA profile
+
+# meeting_muscle_strengthening_recommendations  14001
+# adults_very_low_activity                      14002
+# children_very_low_activity                    14003
+# children_participating_sport                  14006
+# children_active_play                          14007
+
+shes_df <- shes_df %>%
+  filter(!(ind_id %in% c(14001, 14002, 14003, 14006, 14007)))
 
 
 ### 7. Prepare final files -----
@@ -399,7 +424,6 @@ prepare_final_files(ind = "fruit_veg_consumption")
 prepare_final_files(ind = "common_mh_probs")
 prepare_final_files(ind = "mental_wellbeing") 
 prepare_final_files(ind = "physical_activity")
-#prepare_final_files(ind = "meets_mvpa_and_strength_recs")
 prepare_final_files(ind = "binge_drinking")
 prepare_final_files(ind = "problem_drinker")
 prepare_final_files(ind = "weekly_alc_units")
@@ -425,6 +449,13 @@ prepare_final_files(ind = "cyp_sdq_hyperactivity")
 prepare_final_files(ind = "cyp_sdq_emotional")
 prepare_final_files(ind = "cyp_sdq_prosocial")
 
+# # run these when ready to publish PA profile
+# prepare_final_files(ind = "meeting_muscle_strengthening_recommendations")
+# prepare_final_files(ind = "adults_very_low_activity")
+# prepare_final_files(ind = "children_very_low_activity")
+# prepare_final_files(ind = "children_participating_sport")
+# prepare_final_files(ind = "children_active_play")
+
 
 # Run QA reports 
 # main data
@@ -436,7 +467,6 @@ run_qa(type = "main", filename = "mental_wellbeing", test_file = FALSE)
 run_qa(type = "main", filename = "physical_activity", test_file = FALSE) 
 run_qa(type = "main", filename = "fruit_veg_consumption", test_file = FALSE) 
 run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) 
-#run_qa(type = "main", filename = "meets_mvpa_and_strength_recs", test_file = FALSE)  
 run_qa(type = "main", filename = "binge_drinking", test_file = FALSE)  
 run_qa(type = "main", filename = "problem_drinker", test_file = FALSE)  
 run_qa(type = "main", filename = "weekly_alc_units", test_file = FALSE)  
@@ -462,6 +492,13 @@ run_qa(type = "main", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "main", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "main", filename = "cyp_sdq_prosocial", test_file = FALSE)
 
+# # run these when ready to publish PA profile
+# run_qa(type = "main", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+# run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
+# run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE)
+# run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
+# run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
+
 
 # ineq data: 
 run_qa(type = "deprivation", filename = "self_assessed_health", test_file=FALSE)
@@ -472,7 +509,6 @@ run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file=FALSE
 run_qa(type = "deprivation", filename = "common_mh_probs", test_file=FALSE)
 run_qa(type = "deprivation", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "deprivation", filename = "physical_activity", test_file=FALSE)
-#run_qa(type = "deprivation", filename = "meets_mvpa_and_strength_recs", test_file=FALSE)
 run_qa(type = "deprivation", filename = "binge_drinking", test_file=FALSE)
 run_qa(type = "deprivation", filename = "problem_drinker", test_file=FALSE) # PAF data for this indicator a bit peculiar since gradient isn't simple (quintile 4 highest) - consider excluding just the PAF dat afor this indicator on next update? 
 run_qa(type = "deprivation", filename = "weekly_alc_units", test_file=FALSE)
@@ -498,6 +534,13 @@ run_qa(type = "deprivation", filename = "cyp_sdq_hyperactivity", test_file = FAL
 run_qa(type = "deprivation", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_prosocial", test_file = FALSE)
 
+# # run these when ready to publish PA profile
+# run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+# run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
+# run_qa(type = "deprivation", filename = "children_very_low_activity", test_file = FALSE)
+# run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
+# run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
+
 # popgrp data: 
 run_qa(type = "popgrp", filename = "self_assessed_health", test_file=FALSE)
 run_qa(type = "popgrp", filename = "limiting_long_term_condition", test_file=FALSE)
@@ -507,7 +550,6 @@ run_qa(type = "popgrp", filename = "fruit_veg_consumption", test_file=FALSE)
 run_qa(type = "popgrp", filename = "common_mh_probs", test_file=FALSE)
 run_qa(type = "popgrp", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "popgrp", filename = "physical_activity", test_file=FALSE)
-#run_qa(type = "popgrp", filename = "meets_mvpa_and_strength_recs", test_file=FALSE)
 run_qa(type = "popgrp", filename = "binge_drinking", test_file=FALSE)
 run_qa(type = "popgrp", filename = "problem_drinker", test_file=FALSE) 
 run_qa(type = "popgrp", filename = "weekly_alc_units", test_file=FALSE)
@@ -532,6 +574,13 @@ run_qa(type = "popgrp", filename = "cyp_sdq_conduct", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_prosocial", test_file = FALSE)
+
+# # run these when ready to publish PA profile
+# run_qa(type = "popgrp", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+# run_qa(type = "popgrp", filename = "adults_very_low_activity", test_file = FALSE)
+# run_qa(type = "popgrp", filename = "children_very_low_activity", test_file = FALSE)
+# run_qa(type = "popgrp", filename = "children_participating_sport", test_file = FALSE)
+# run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
 
 
 #END

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -145,11 +145,8 @@ shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the enviro
                                  split_value=="4th quintile" ~ "4",
                                  split_value=="5th-Bottom quintile" ~ "5 - lowest income",
                                  TRUE ~ split_value)) %>%
-  mutate(split_value = ifelse(split_name=="Age" & split_value!="Total",
-                              paste0(split_value, " y"), # add y for years to age groups
-                              split_value)) %>%
-  mutate(split_name = ifelse(split_name=="Age", "Age group", split_name)) %>%
-  
+  filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
+
   # keep the required columns
   select(code, ind = `Scottish Health Survey Indicator`, trend_axis, split_name, split_value, stat, value = Value) %>%
   
@@ -276,8 +273,7 @@ shes_df <- shes_df %>%
 # (and standardise the split_names and split_values)
 shes_df <- shes_from_ukds %>%
   rbind(shes_df) %>%
-  mutate(split_name=case_when(split_name=="Age" ~ "Age group",
-                              split_name=="Long-term Illness" ~ "Long-term illness",
+  mutate(split_name=case_when(split_name=="Long-term Illness" ~ "Long-term illness",
                               TRUE ~ split_name)) %>%
   # published data refers to long term 'conditions' but the this is used interchangeably with 'illness' in the reporting. Here we standardise these:
   mutate(split_value=case_when(split_value %in% c("No long-term conditions", "No Long-term Illness") ~ "No long-term illness",
@@ -367,14 +363,14 @@ prepare_final_files <- function(ind){
              (geog!="S00" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
     select(-indicator, -sex, -geog) %>%
     mutate(split_value = factor(split_value, 
-                                levels = c("Total", "0-3 years","2-3 years", "4-6 years", "7-9 years", "10-12 years",  
-                                           "13-15 years", "16-24 y", "25-34 y", "35-44 y", "45-54 y", "55-64 y", "65-74 y", "75+ y",  
-                                           "1 - highest income","2","3","4", "5 - lowest income","Female","Male",            
-                                           "No long-term conditions", "Non-limiting long-term conditions","Limiting long-term conditions"),
-                                labels = c("Total", "0-3 years","2-3 years", "4-6 years", "7-9 years", "10-12 years",  
-                                           "13-15 years", "16-24 y", "25-34 y", "35-44 y", "45-54 y", "55-64 y", "65-74 y", "75+ y",  
-                                           "1 - highest income","2","3","4", "5 - lowest income","Female","Male",            
-                                           "No long-term conditions", "Non-limiting long-term conditions","Limiting long-term conditions"))) %>%
+                                levels = c("Total", "0 to 4y","2-4y", "4 to 11y", "5 to 11y", "12 to 15y",  
+                                           "16 to 64y", "65y and over", 
+                                           "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
+                                           "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"),
+                                labels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "5 to 11y", "12 to 15y",  
+                                           "16 to 64y", "65y and over", 
+                                           "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",           
+                                           "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"))) %>%
     arrange(code, year, split_name, split_value)
   
   # Save

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -110,13 +110,13 @@ library(opendatascot) # for getting data from stats.gov.scot
 
 ### 1. Read in the downloaded and saved data ----
 
-# Published data from statistics.gov.scot:
-SHeS_SCOTLAND <- read_parquet(paste0(profiles_data_folder,"/Received Data/Scottish Health Survey/SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
-SHeS_LA <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
-SHeS_SIMD <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
-SHeS_AGE <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_AGE.parquet")) %>% mutate(split_name = "Age")
-SHeS_INCOME <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
-SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
+# # Published data from statistics.gov.scot:
+# SHeS_SCOTLAND <- read_parquet(paste0(profiles_data_folder,"/Received Data/Scottish Health Survey/SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
+# SHeS_LA <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
+# SHeS_SIMD <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
+# SHeS_AGE <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_AGE.parquet")) %>% mutate(split_name = "Age")
+# SHeS_INCOME <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
+# SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
 
 # Pre-processed UKDS data (UK data service)
 # The data read in below is prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
@@ -124,155 +124,156 @@ SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Sco
 shes_from_ukds <- readRDS(paste0(profiles_data_folder, "/Prepared Data/shes_raw.rds")) %>%
   mutate(code = as.character(code))
 
-###------------------------------------------------------------------------------------------------
-### PUBLISHED DATA PROCESSING:
-### 2. Combine data and get column data and formats right----
-shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
-  bind_rows() %>% # append them together
-  mutate(code = ifelse(FeatureCode=="S92000003", "S00000001", FeatureCode)) %>% # recode Scotland
-  mutate(stat = case_when(Measurement=="95% Lower Confidence Limit" ~ "lowci", # recode the measures
-                          Measurement=="95% Upper Confidence Limit" ~ "upci",
-                          Measurement %in% c("Mean", "Percent") ~ "rate")) %>%
-  rename(trend_axis = DateCode) %>%
-  # create a new split_value column: coalesce combines non-NA values into a single column
-  mutate(split_value = coalesce(Age, Sex, `Long-term illness`, `Equivalised Income`, `SIMD quintiles`)) %>% # this works because there is only ever one non-NA cell in these 5 columns
-  mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
-  mutate(split_value = case_when(split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
-                                 split_value=="5 - least deprived" ~ "5",
-                                 split_value=="1st-Top quintile" ~ "1 - highest income", # match ScotPHO format
-                                 split_value=="2nd quintile" ~ "2",
-                                 split_value=="3rd quintile" ~ "3",
-                                 split_value=="4th quintile" ~ "4",
-                                 split_value=="5th-Bottom quintile" ~ "5 - lowest income",
-                                 TRUE ~ split_value)) %>%
-  filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
-  
-  # keep the required columns
-  select(code, ind = `Scottish Health Survey Indicator`, trend_axis, split_name, split_value, stat, value = Value) %>%
-  
-  # reshape to wide
-  pivot_wider(names_from=stat, values_from = value) %>%
-  
-  # add def_period column
-  # first need to calculate the difference (year_diff) between the first and last year in the trend_axis to work out what def_period to add
-  # this calc copes with single year (e.g. year_diff for 2008 = 0), two years (year_diff for 2010-2011 = 1), 
-  # and the aggregates used for lower geogs (year_diff = 3 if not including 2020, or 4 if 2020 is in the range, because 2020 data are excluded)
-  mutate(year_diff = 
-           as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
-         - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
-  mutate(year = case_when(year_diff <= 1 ~ as.numeric(substr(trend_axis, 1, 4)), # year = first/only year in the label
-                          year_diff>1 ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
-  mutate(def_period = ifelse(year_diff <= 1, 
-                             paste0("Survey year (", trend_axis, ")"),
-                             paste0("Aggregated survey years (", trend_axis, ")"))) %>%
-  mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
-         sex = "Total")
-
-
-### 3. Which indicators should be kept? ----
-
-# print out list of all available indicators in the data:
-unique(shes_df$ind)
-# look through to check which ones we need to keep
-
-# # check LLTI data: 
-# # there are 2 similarly-named indicators for LLTI. 
-# # they have overlapping temporal coverage, so need to look at the splits, geographies, and year-ranges involved
-# llti <- shes_df %>% 
-#   filter(ind %in% c("Long-term conditions: Limiting long-term conditions", 
-#                     "Long-term illness: Limiting long-term illness")) %>%
-#   mutate(geog = substr(code, 1, 3)) %>%
-#   select(ind, split_name, geog, year_diff) %>%
-#   unique() %>% 
-#   pivot_wider(names_from = split_name, values_from = year_diff) 
-# # Conclusion: "Long-term conditions" is the one to keep, "Long-term illness" just available for annual Scotland data, for fewer years than the LT conditions data.
-
-# List all the indicators we want to keep:
-keep <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)                   
-          "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)                                                                                     
-          "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)                                                                              
-          "Food insecurity (worried would run out of food): Yes",  # 99105                                                                        
-          "Healthy weight: Healthy weight", #99106                                                                                              
-          "Summary activity levels: Meets recommendations",  #99107 
-          #  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations", #14001 #NOT PUBLISHED YET
-          "Self-assessed general health: Very good/Good",    # 99108                                                                             
-          "Fruit & vegetable consumption: 5 portions or more",  #30013                                                                          
-          "Mental wellbeing", # 30001 (mean score, as in the indicator definition)                                                                                                           
-          "General health questionnaire (GHQ-12): Score 4+", # 30003                                                                             
-          "Long-term conditions: Limiting long-term conditions" # 99109 
-          #   "Long-term illness: Limiting long-term illness",  # 99109                                                                           
-          #   "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)", # 30002 (better definition than existing: mean score?)                                                             
-          #   "Symptoms of anxiety: No anxiety symptoms", # 30005: would need the inverse... would this be valid?                                                                                    
-          #   "Symptoms of depression: No depression symptoms", # 30004: would need the inverse... would this be valid?                                                                               
-)                                                                    
-
-
-# keep the required indicators
-shes_df <- shes_df %>%
-  filter(ind %in% keep)
-
-### 4. Further processing:  ----
-
-shes_df <- shes_df %>% 
-  
-  # Add shorter indicator name column (used as filename)
-  mutate(indicator = case_when(ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",
-                               ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",
-                               ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
-                               ind == "Food insecurity (worried would run out of food): Yes" ~ "food_insecurity",
-                               ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption", 
-                               ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs", 
-                               ind == "Mental wellbeing" ~ "mental_wellbeing", 
-                               ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
-                               #    ind == "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" ~ "meets_mvpa_and_strength_recs",
-                               ind == "Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" ~ "binge_drinking",
-                               ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
-                               ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units"),
-         # Create new ind_id column
-         ind_id = case_when(indicator == "self_assessed_health" ~ 99108,
-                            indicator == "limiting_long_term_condition" ~ 99109,
-                            indicator == "healthy_weight" ~ 99106,
-                            indicator == "food_insecurity" ~ 99105,
-                            indicator == "fruit_veg_consumption" ~ 30013, 
-                            indicator == "common_mh_probs" ~ 30003, 
-                            indicator == "mental_wellbeing" ~ 30001, 
-                            indicator == "physical_activity" ~ 99107,
-                            #    indicator == "meets_mvpa_and_strength_recs" ~ 14001,
-                            indicator == "binge_drinking" ~ 4170,
-                            indicator == "problem_drinker" ~ 4171,
-                            indicator == "weekly_alc_units" ~ 4172)) %>% 
-  
-  # Select relevant columns
-  select(ind_id, indicator, code, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator)
-
-### 5. Add totals for the popgroup and SIMD splits ----
-# (some have totals but some don't...)
-
-# Get split_value = "Total" for the splits without totals.
-# This is needed for subsequent calculation of the inequalities metrics, and is nice-to-have for the popgroup data:
-splits_w_no_total <- shes_df %>%
-  group_by(indicator, split_name) %>%
-  mutate(has_total = "Total" %in% split_value) %>%
-  ungroup() %>%
-  filter(has_total==FALSE) %>%
-  select(code, indicator, ind_id, trend_axis, year, def_period, sex, split_name) %>%
-  unique()
-
-totals_to_add <- shes_df %>%
-  filter(split_value=="Total") %>%
-  select(code, indicator, trend_axis, split_value, rate, lowci, upci, numerator) %>%
-  unique() %>%
-  merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis"), all.y=TRUE)
-
-shes_df <- shes_df %>%
-  rbind(totals_to_add)
+# Mar 2026: no 2024 data in the statistics.gov.scot data yet, so keep all from UKDS raw microdata (all years)
+# ###------------------------------------------------------------------------------------------------
+# ### PUBLISHED DATA PROCESSING:
+# ### 2. Combine data and get column data and formats right----
+# shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
+#   bind_rows() %>% # append them together
+#   mutate(code = ifelse(FeatureCode=="S92000003", "S00000001", FeatureCode)) %>% # recode Scotland
+#   mutate(stat = case_when(Measurement=="95% Lower Confidence Limit" ~ "lowci", # recode the measures
+#                           Measurement=="95% Upper Confidence Limit" ~ "upci",
+#                           Measurement %in% c("Mean", "Percent") ~ "rate")) %>%
+#   rename(trend_axis = DateCode) %>%
+#   # create a new split_value column: coalesce combines non-NA values into a single column
+#   mutate(split_value = coalesce(Age, Sex, `Long-term illness`, `Equivalised Income`, `SIMD quintiles`)) %>% # this works because there is only ever one non-NA cell in these 5 columns
+#   mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
+#   mutate(split_value = case_when(split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
+#                                  split_value=="5 - least deprived" ~ "5",
+#                                  split_value=="1st-Top quintile" ~ "1 - highest income", # match ScotPHO format
+#                                  split_value=="2nd quintile" ~ "2",
+#                                  split_value=="3rd quintile" ~ "3",
+#                                  split_value=="4th quintile" ~ "4",
+#                                  split_value=="5th-Bottom quintile" ~ "5 - lowest income",
+#                                  TRUE ~ split_value)) %>%
+#   filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
+#   
+#   # keep the required columns
+#   select(code, ind = `Scottish Health Survey Indicator`, trend_axis, split_name, split_value, stat, value = Value) %>%
+#   
+#   # reshape to wide
+#   pivot_wider(names_from=stat, values_from = value) %>%
+#   
+#   # add def_period column
+#   # first need to calculate the difference (year_diff) between the first and last year in the trend_axis to work out what def_period to add
+#   # this calc copes with single year (e.g. year_diff for 2008 = 0), two years (year_diff for 2010-2011 = 1), 
+#   # and the aggregates used for lower geogs (year_diff = 3 if not including 2020, or 4 if 2020 is in the range, because 2020 data are excluded)
+#   mutate(year_diff = 
+#            as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
+#          - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
+#   mutate(year = case_when(year_diff <= 1 ~ as.numeric(substr(trend_axis, 1, 4)), # year = first/only year in the label
+#                           year_diff>1 ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
+#   mutate(def_period = ifelse(year_diff <= 1, 
+#                              paste0("Survey year (", trend_axis, ")"),
+#                              paste0("Aggregated survey years (", trend_axis, ")"))) %>%
+#   mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
+#          sex = "Total")
+# 
+# 
+# ### 3. Which indicators should be kept? ----
+# 
+# # print out list of all available indicators in the data:
+# unique(shes_df$ind)
+# # look through to check which ones we need to keep
+# 
+# # # check LLTI data: 
+# # # there are 2 similarly-named indicators for LLTI. 
+# # # they have overlapping temporal coverage, so need to look at the splits, geographies, and year-ranges involved
+# # llti <- shes_df %>% 
+# #   filter(ind %in% c("Long-term conditions: Limiting long-term conditions", 
+# #                     "Long-term illness: Limiting long-term illness")) %>%
+# #   mutate(geog = substr(code, 1, 3)) %>%
+# #   select(ind, split_name, geog, year_diff) %>%
+# #   unique() %>% 
+# #   pivot_wider(names_from = split_name, values_from = year_diff) 
+# # # Conclusion: "Long-term conditions" is the one to keep, "Long-term illness" just available for annual Scotland data, for fewer years than the LT conditions data.
+# 
+# # List all the indicators we want to keep:
+# keep <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)                   
+#           "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)                                                                                     
+#           "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)                                                                              
+#           "Food insecurity (worried would run out of food): Yes",  # 99105                                                                        
+#           "Healthy weight: Healthy weight", #99106                                                                                              
+#           "Summary activity levels: Meets recommendations",  #99107 
+#           #  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations", #14001 #NOT PUBLISHED YET
+#           "Self-assessed general health: Very good/Good",    # 99108                                                                             
+#           "Fruit & vegetable consumption: 5 portions or more",  #30013                                                                          
+#           "Mental wellbeing", # 30001 (mean score, as in the indicator definition)                                                                                                           
+#           "General health questionnaire (GHQ-12): Score 4+", # 30003                                                                             
+#           "Long-term conditions: Limiting long-term conditions" # 99109 
+#           #   "Long-term illness: Limiting long-term illness",  # 99109                                                                           
+#           #   "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)", # 30002 (better definition than existing: mean score?)                                                             
+#           #   "Symptoms of anxiety: No anxiety symptoms", # 30005: would need the inverse... would this be valid?                                                                                    
+#           #   "Symptoms of depression: No depression symptoms", # 30004: would need the inverse... would this be valid?                                                                               
+# )                                                                    
+# 
+# 
+# # keep the required indicators
+# shes_df <- shes_df %>%
+#   filter(ind %in% keep)
+# 
+# ### 4. Further processing:  ----
+# 
+# shes_df <- shes_df %>% 
+#   
+#   # Add shorter indicator name column (used as filename)
+#   mutate(indicator = case_when(ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",
+#                                ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",
+#                                ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
+#                                ind == "Food insecurity (worried would run out of food): Yes" ~ "food_insecurity",
+#                                ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption", 
+#                                ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs", 
+#                                ind == "Mental wellbeing" ~ "mental_wellbeing", 
+#                                ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
+#                                #    ind == "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" ~ "meets_mvpa_and_strength_recs",
+#                                ind == "Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" ~ "binge_drinking",
+#                                ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
+#                                ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units"),
+#          # Create new ind_id column
+#          ind_id = case_when(indicator == "self_assessed_health" ~ 99108,
+#                             indicator == "limiting_long_term_condition" ~ 99109,
+#                             indicator == "healthy_weight" ~ 99106,
+#                             indicator == "food_insecurity" ~ 99105,
+#                             indicator == "fruit_veg_consumption" ~ 30013, 
+#                             indicator == "common_mh_probs" ~ 30003, 
+#                             indicator == "mental_wellbeing" ~ 30001, 
+#                             indicator == "physical_activity" ~ 99107,
+#                             #    indicator == "meets_mvpa_and_strength_recs" ~ 14001,
+#                             indicator == "binge_drinking" ~ 4170,
+#                             indicator == "problem_drinker" ~ 4171,
+#                             indicator == "weekly_alc_units" ~ 4172)) %>% 
+#   
+#   # Select relevant columns
+#   select(ind_id, indicator, code, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator)
+# 
+# ### 5. Add totals for the popgroup and SIMD splits ----
+# # (some have totals but some don't...)
+# 
+# # Get split_value = "Total" for the splits without totals.
+# # This is needed for subsequent calculation of the inequalities metrics, and is nice-to-have for the popgroup data:
+# splits_w_no_total <- shes_df %>%
+#   group_by(indicator, split_name) %>%
+#   mutate(has_total = "Total" %in% split_value) %>%
+#   ungroup() %>%
+#   filter(has_total==FALSE) %>%
+#   select(code, indicator, ind_id, trend_axis, year, def_period, sex, split_name) %>%
+#   unique()
+# 
+# totals_to_add <- shes_df %>%
+#   filter(split_value=="Total") %>%
+#   select(code, indicator, trend_axis, split_value, rate, lowci, upci, numerator) %>%
+#   unique() %>%
+#   merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis"), all.y=TRUE)
+# 
+# shes_df <- shes_df %>%
+#   rbind(totals_to_add)
 
 
 ###------------------------------------------------------------------------------------------------
 ### Now add the UKDS data:
 # (and standardise the split_names and split_values)
 shes_df <- shes_from_ukds %>%
-  rbind(shes_df) %>%
+ # rbind(shes_df) %>%
   mutate(split_name=case_when(split_name=="Long-term Illness" ~ "Long-term illness",
                               TRUE ~ split_name)) %>%
   # published data refers to long term 'conditions' but the this is used interchangeably with 'illness' in the reporting. Here we standardise these:
@@ -281,9 +282,9 @@ shes_df <- shes_from_ukds %>%
                                split_value %in% c("Limiting long-term conditions", "Non-limiting Long-term Illness") ~ "Non-limiting long-term illness",
                                TRUE ~ split_value))
 
-table(shes_df$ind_id, useNA="always") # 37 in total, no NA
-table(shes_df$indicator, useNA="always") # 37 in total, no NA
-table(shes_df$code, useNA="always") # Scot, HB, LA, no NA
+table(shes_df$ind_id, useNA="always") # 32 in total, no NA
+table(shes_df$indicator, useNA="always") # 32 in total, no NA
+table(shes_df$code, useNA="always") # Scot, HB, no LA, no NA
 table(shes_df$trend_axis, useNA="always") # 2008 to 2023, single year and 4-y aggregates, no NA
 table(shes_df$def_period, useNA="always") # 2008 to 2023, single year and 4-y aggregates, no NA
 table(shes_df$sex, useNA="always") # M/F/total, no NA
@@ -320,17 +321,17 @@ indicators_w_lower_geogs <- availability %>%
 indicators_w_lower_geogs <- as.vector(indicators_w_lower_geogs$indicator)
 
 
-### TEMPORARY STEP: drop the indicators we're not publishing yet: the PA profile
-
-# meeting_muscle_strengthening_recommendations  14001
-# adults_very_low_activity                      14002
-# children_very_low_activity                    14003
-# children_participating_sport                  14006
-# children_active_play                          14007
-
-shes_df <- shes_df %>%
-  filter(!(ind_id %in% c(14001, 14002, 14003, 14006, 14007)))
-
+# ### TEMPORARY STEP: drop the indicators we're not publishing yet: the PA profile
+# 
+# # meeting_muscle_strengthening_recommendations  14001
+# # adults_very_low_activity                      14002
+# # children_very_low_activity                    14003
+# # children_participating_sport                  14006
+# # children_active_play                          14007
+# 
+# shes_df <- shes_df %>%
+#   filter(!(ind_id %in% c(14001, 14002, 14003, 14006, 14007)))
+# 
 
 ### 7. Prepare final files -----
 
@@ -453,13 +454,11 @@ prepare_final_files(ind = "cyp_sdq_conduct")
 prepare_final_files(ind = "cyp_sdq_hyperactivity")
 prepare_final_files(ind = "cyp_sdq_emotional")
 prepare_final_files(ind = "cyp_sdq_prosocial")
-
-# # run these when ready to publish PA profile
-# prepare_final_files(ind = "meeting_muscle_strengthening_recommendations")
-# prepare_final_files(ind = "adults_very_low_activity")
-# prepare_final_files(ind = "children_very_low_activity")
-# prepare_final_files(ind = "children_participating_sport")
-# prepare_final_files(ind = "children_active_play")
+prepare_final_files(ind = "meeting_muscle_strengthening_recommendations")
+prepare_final_files(ind = "adults_very_low_activity")
+prepare_final_files(ind = "children_very_low_activity")
+prepare_final_files(ind = "children_participating_sport")
+prepare_final_files(ind = "children_active_play")
 
 
 # Run QA reports 
@@ -496,13 +495,11 @@ run_qa(type = "main", filename = "cyp_sdq_conduct", test_file = FALSE)
 run_qa(type = "main", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "main", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "main", filename = "cyp_sdq_prosocial", test_file = FALSE)
-
-# # run these when ready to publish PA profile
-# run_qa(type = "main", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
-# run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
-# run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE)
-# run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
-# run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "main", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
+run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE)
+run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
+run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
 
 
 # ineq data: 
@@ -538,13 +535,11 @@ run_qa(type = "deprivation", filename = "cyp_sdq_conduct", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_prosocial", test_file = FALSE)
-
-# # run these when ready to publish PA profile
-# run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
-# run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
-# run_qa(type = "deprivation", filename = "children_very_low_activity", test_file = FALSE)
-# run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
-# run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
+run_qa(type = "deprivation", filename = "children_very_low_activity", test_file = FALSE)
+run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
+run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
 
 # popgrp data: 
 run_qa(type = "popgrp", filename = "self_assessed_health", test_file=FALSE)
@@ -579,13 +574,11 @@ run_qa(type = "popgrp", filename = "cyp_sdq_conduct", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_prosocial", test_file = FALSE)
-
-# # run these when ready to publish PA profile
-# run_qa(type = "popgrp", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
-# run_qa(type = "popgrp", filename = "adults_very_low_activity", test_file = FALSE)
-# run_qa(type = "popgrp", filename = "children_very_low_activity", test_file = FALSE)
-# run_qa(type = "popgrp", filename = "children_participating_sport", test_file = FALSE)
-# run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "popgrp", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+run_qa(type = "popgrp", filename = "adults_very_low_activity", test_file = FALSE)
+run_qa(type = "popgrp", filename = "children_very_low_activity", test_file = FALSE)
+run_qa(type = "popgrp", filename = "children_participating_sport", test_file = FALSE)
+run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
 
 
 #END

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -1,13 +1,12 @@
 # TO DO:
 # look at other indicators that could be sourced from SHeS bulk data in this script.
-# look at whether the data published for the mus_rec PA indicator  on the SHeS dashboard should be used where available
 
 #########################################################
 # Scottish Health Survey data import
 #########################################################
 
 
-### Update the 13 ScotPHO indicators that can be sourced from published Scottish Health Survey data: 
+### Update the 11 ScotPHO indicators that can be sourced from published Scottish Health Survey data: 
 
 ### Care and Wellbeing indicators: 
 #   99105: Food insecurity
@@ -19,19 +18,15 @@
 #   30013: Fruit & vegetable consumption (guidelines) *
 #   30003: General health questionnaire (GHQ-12) *
 #   30001: Mental wellbeing (WEMWBS)*
-### CYP mental health indicators:
-#   30111: Children meeting PA recommendations (>1 hour every day) (NB. not in statistics.scot.gov data quite yet: try end 2025/early 2026? Used to come from HBSC, but changed to SHeS in 2026)
 ### Alcohol profile indicators:
 #   4170: Alcohol consumption: Binge drinking (drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" (previous indicator definition excluded non-drinkers from denom)
 #   4171: Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here) 
 #   4172: Alcohol consumption (mean weekly units)"
-### Physical activity profile:
-#   14001:  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" N.B. INDICATOR NOT PUBLISHED YET: PUT IN TECHDOC WHEN READY TO PUBLISH.
 
-### And adding data for a further 24 indicators (13 adult, 11 CYP) that have been processed in the ScotPHO_survey_data repo 
+### And adding data for a further 25 indicators (14 adult, 12 CYP) that have been processed in the ScotPHO_survey_data repo 
 ### (raw data processing elsewhere because they use UK Data Service data)
 ### (data for SIMD x sex are also added for the 6 published variables above that are in the adult MH profile (see *), as these can be derived from the UKDS data.)
-### (NB mus_rec (Adults meeting muscle strengthening guidelines) is also published in the open data: look at whether the published data should be used where available)
+### (Mar 2026: stat.gov.scot data not published for 2024 yet, so will just use the additional geog - CA - for the indicators we get from UKDS)
 
 # Adult:
 # 30002 = life_sat	Mean score on the question "All things considered, how satisfied are you with your life as a whole nowadays?" (variable LifeSat).  N.B. This indicator is also available from the ScotPHO Online Profiles (national and council area level, but not by SIMD). Life satisfaction is measured by asking participants to rate, on a scale of 0 to 10, how satisfied they are with their life in general. On the scale, 0 represented 'extremely dissatisfied' and 10 'extremely satisfied' (the intervening scale points were numbered but not labelled). 
@@ -47,26 +42,22 @@
 # 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
 # 30026 = rg17a_new	Percentage of adults who provide 20 or more hours of care per week to a member of their household or to someone not living with them, excluding help provided in the course of employment. Participants were asked whether they look after, or give any regular help or support to, family members, friends, neighbours or others because of a long-term physical condition, mental ill-health or disability; or problems related to old age. Caring which is done as part of any paid employment is not asked about. From 2014 onwards, this question explicitly instructed respondents to exclude caring as part of paid employment. The variables used to construc this indicator were RG15aNew (Do you provide any regular help or care for any sick, disabled, or frail people?) and RG17aNew (How many hours do you spend each week providing help or unpaid care for him/her/them?). 
 # 14002 - adt10gp_tw_LOW - Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
+# 14001 - mus_rec - Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
 
 # CYP:
 # 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
 # 30129 = ch_audit  Percentage of children aged 15 years or under with a parent/carer who reports consuming alcohol at hazardous or harmful levels (AUDIT questionnaire score 8+)
-# 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
 # 30170	Peer relationship problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the peer relationship problems scale of the Strengths and Difficulties Questionnaire (SDQ)
+# 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
 # 30172	Emotional symptoms - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 4-10) on the emotional symptoms scale of the Strengths and Difficulties Questionnaire (SDQ)
 # 30173	Conduct problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the conduct problems scale of the Strengths and Difficulties Questionnaire (SDQ)
 # 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
 # 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
+# 30111 % children meeting 1 hour PA per day
 # 14003 - c00sum7s - Children with very low activity levels
 # 14006 - spt1ch - Children participating in sport
 # 14007 - ch30plyg - Children engaging in active play
 
-# NB. These indicators won't be produced until the PA profile is ready to be published:
-# 14001 - mus_rec - Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
-# 14002 - adt10gp_tw_LOW - Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
-# 14003 - c00sum7s - Children with very low activity levels
-# 14006 - spt1ch - Children participating in sport
-# 14007 - ch30plyg - Children engaging in active play
 
 # The published data are downloaded from statistics.gov.scot:
 # https://statistics.gov.scot/data/search?search=scottish+health+survey
@@ -110,170 +101,188 @@ library(opendatascot) # for getting data from stats.gov.scot
 
 ### 1. Read in the downloaded and saved data ----
 
-# # Published data from statistics.gov.scot:
-# SHeS_SCOTLAND <- read_parquet(paste0(profiles_data_folder,"/Received Data/Scottish Health Survey/SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
-# SHeS_LA <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
-# SHeS_SIMD <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
-# SHeS_AGE <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_AGE.parquet")) %>% mutate(split_name = "Age")
-# SHeS_INCOME <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
-# SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
+# Published data from statistics.gov.scot:
+SHeS_SCOTLAND <- read_parquet(paste0(profiles_data_folder,"/Received Data/Scottish Health Survey/SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
+SHeS_LA <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
+SHeS_SIMD <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
+SHeS_AGE <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_AGE.parquet")) %>% mutate(split_name = "Age")
+SHeS_INCOME <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
+SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
 
 # Pre-processed UKDS data (UK data service)
 # The data read in below is prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# Last updated Jan 2026 (SHeS data up to 2023)
+# Last updated Mar 2026 (SHeS data up to 2024)
 shes_from_ukds <- readRDS(paste0(profiles_data_folder, "/Prepared Data/shes_raw.rds")) %>%
   mutate(code = as.character(code))
 
 # Mar 2026: no 2024 data in the statistics.gov.scot data yet, so keep all from UKDS raw microdata (all years)
-# ###------------------------------------------------------------------------------------------------
-# ### PUBLISHED DATA PROCESSING:
-# ### 2. Combine data and get column data and formats right----
-# shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
-#   bind_rows() %>% # append them together
-#   mutate(code = ifelse(FeatureCode=="S92000003", "S00000001", FeatureCode)) %>% # recode Scotland
-#   mutate(stat = case_when(Measurement=="95% Lower Confidence Limit" ~ "lowci", # recode the measures
-#                           Measurement=="95% Upper Confidence Limit" ~ "upci",
-#                           Measurement %in% c("Mean", "Percent") ~ "rate")) %>%
-#   rename(trend_axis = DateCode) %>%
-#   # create a new split_value column: coalesce combines non-NA values into a single column
-#   mutate(split_value = coalesce(Age, Sex, `Long-term illness`, `Equivalised Income`, `SIMD quintiles`)) %>% # this works because there is only ever one non-NA cell in these 5 columns
-#   mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
-#   mutate(split_value = case_when(split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
-#                                  split_value=="5 - least deprived" ~ "5",
-#                                  split_value=="1st-Top quintile" ~ "1 - highest income", # match ScotPHO format
-#                                  split_value=="2nd quintile" ~ "2",
-#                                  split_value=="3rd quintile" ~ "3",
-#                                  split_value=="4th quintile" ~ "4",
-#                                  split_value=="5th-Bottom quintile" ~ "5 - lowest income",
-#                                  TRUE ~ split_value)) %>%
-#   filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
-#   
-#   # keep the required columns
-#   select(code, ind = `Scottish Health Survey Indicator`, trend_axis, split_name, split_value, stat, value = Value) %>%
-#   
-#   # reshape to wide
-#   pivot_wider(names_from=stat, values_from = value) %>%
-#   
-#   # add def_period column
-#   # first need to calculate the difference (year_diff) between the first and last year in the trend_axis to work out what def_period to add
-#   # this calc copes with single year (e.g. year_diff for 2008 = 0), two years (year_diff for 2010-2011 = 1), 
-#   # and the aggregates used for lower geogs (year_diff = 3 if not including 2020, or 4 if 2020 is in the range, because 2020 data are excluded)
-#   mutate(year_diff = 
-#            as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
-#          - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
-#   mutate(year = case_when(year_diff <= 1 ~ as.numeric(substr(trend_axis, 1, 4)), # year = first/only year in the label
-#                           year_diff>1 ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
-#   mutate(def_period = ifelse(year_diff <= 1, 
-#                              paste0("Survey year (", trend_axis, ")"),
-#                              paste0("Aggregated survey years (", trend_axis, ")"))) %>%
-#   mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
-#          sex = "Total")
-# 
-# 
-# ### 3. Which indicators should be kept? ----
-# 
-# # print out list of all available indicators in the data:
-# unique(shes_df$ind)
-# # look through to check which ones we need to keep
-# 
-# # # check LLTI data: 
-# # # there are 2 similarly-named indicators for LLTI. 
-# # # they have overlapping temporal coverage, so need to look at the splits, geographies, and year-ranges involved
-# # llti <- shes_df %>% 
-# #   filter(ind %in% c("Long-term conditions: Limiting long-term conditions", 
-# #                     "Long-term illness: Limiting long-term illness")) %>%
-# #   mutate(geog = substr(code, 1, 3)) %>%
-# #   select(ind, split_name, geog, year_diff) %>%
-# #   unique() %>% 
-# #   pivot_wider(names_from = split_name, values_from = year_diff) 
-# # # Conclusion: "Long-term conditions" is the one to keep, "Long-term illness" just available for annual Scotland data, for fewer years than the LT conditions data.
-# 
-# # List all the indicators we want to keep:
-# keep <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)                   
-#           "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)                                                                                     
-#           "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)                                                                              
-#           "Food insecurity (worried would run out of food): Yes",  # 99105                                                                        
-#           "Healthy weight: Healthy weight", #99106                                                                                              
-#           "Summary activity levels: Meets recommendations",  #99107 
-#           #  "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations", #14001 #NOT PUBLISHED YET
-#           "Self-assessed general health: Very good/Good",    # 99108                                                                             
-#           "Fruit & vegetable consumption: 5 portions or more",  #30013                                                                          
-#           "Mental wellbeing", # 30001 (mean score, as in the indicator definition)                                                                                                           
-#           "General health questionnaire (GHQ-12): Score 4+", # 30003                                                                             
-#           "Long-term conditions: Limiting long-term conditions" # 99109 
-#           #   "Long-term illness: Limiting long-term illness",  # 99109                                                                           
-#           #   "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)", # 30002 (better definition than existing: mean score?)                                                             
-#           #   "Symptoms of anxiety: No anxiety symptoms", # 30005: would need the inverse... would this be valid?                                                                                    
-#           #   "Symptoms of depression: No depression symptoms", # 30004: would need the inverse... would this be valid?                                                                               
-# )                                                                    
-# 
-# 
-# # keep the required indicators
-# shes_df <- shes_df %>%
-#   filter(ind %in% keep)
-# 
-# ### 4. Further processing:  ----
-# 
-# shes_df <- shes_df %>% 
-#   
-#   # Add shorter indicator name column (used as filename)
-#   mutate(indicator = case_when(ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",
-#                                ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",
-#                                ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
-#                                ind == "Food insecurity (worried would run out of food): Yes" ~ "food_insecurity",
-#                                ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption", 
-#                                ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs", 
-#                                ind == "Mental wellbeing" ~ "mental_wellbeing", 
-#                                ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
-#                                #    ind == "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" ~ "meets_mvpa_and_strength_recs",
-#                                ind == "Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" ~ "binge_drinking",
-#                                ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
-#                                ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units"),
-#          # Create new ind_id column
-#          ind_id = case_when(indicator == "self_assessed_health" ~ 99108,
-#                             indicator == "limiting_long_term_condition" ~ 99109,
-#                             indicator == "healthy_weight" ~ 99106,
-#                             indicator == "food_insecurity" ~ 99105,
-#                             indicator == "fruit_veg_consumption" ~ 30013, 
-#                             indicator == "common_mh_probs" ~ 30003, 
-#                             indicator == "mental_wellbeing" ~ 30001, 
-#                             indicator == "physical_activity" ~ 99107,
-#                             #    indicator == "meets_mvpa_and_strength_recs" ~ 14001,
-#                             indicator == "binge_drinking" ~ 4170,
-#                             indicator == "problem_drinker" ~ 4171,
-#                             indicator == "weekly_alc_units" ~ 4172)) %>% 
-#   
-#   # Select relevant columns
-#   select(ind_id, indicator, code, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator)
-# 
-# ### 5. Add totals for the popgroup and SIMD splits ----
-# # (some have totals but some don't...)
-# 
-# # Get split_value = "Total" for the splits without totals.
-# # This is needed for subsequent calculation of the inequalities metrics, and is nice-to-have for the popgroup data:
-# splits_w_no_total <- shes_df %>%
-#   group_by(indicator, split_name) %>%
-#   mutate(has_total = "Total" %in% split_value) %>%
-#   ungroup() %>%
-#   filter(has_total==FALSE) %>%
-#   select(code, indicator, ind_id, trend_axis, year, def_period, sex, split_name) %>%
-#   unique()
-# 
-# totals_to_add <- shes_df %>%
-#   filter(split_value=="Total") %>%
-#   select(code, indicator, trend_axis, split_value, rate, lowci, upci, numerator) %>%
+###------------------------------------------------------------------------------------------------
+### PUBLISHED DATA PROCESSING:
+### 2. Combine data and get column data and formats right----
+shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
+  bind_rows() %>% # append them together
+  mutate(code = ifelse(FeatureCode=="S92000003", "S00000001", FeatureCode)) %>% # recode Scotland
+  mutate(stat = case_when(Measurement=="95% Lower Confidence Limit" ~ "lowci", # recode the measures
+                          Measurement=="95% Upper Confidence Limit" ~ "upci",
+                          Measurement %in% c("Mean", "Percent") ~ "rate")) %>%
+  rename(trend_axis = DateCode) %>%
+  # create a new split_value column: coalesce combines non-NA values into a single column
+  mutate(split_value = coalesce(Age, Sex, `Long-term illness`, `Equivalised Income`, `SIMD quintiles`)) %>% # this works because there is only ever one non-NA cell in these 5 columns
+  mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
+  mutate(split_value = case_when(split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
+                                 split_value=="5 - least deprived" ~ "5",
+                                 split_value=="1st-Top quintile" ~ "1 - highest income", # match ScotPHO format
+                                 split_value=="2nd quintile" ~ "2",
+                                 split_value=="3rd quintile" ~ "3",
+                                 split_value=="4th quintile" ~ "4",
+                                 split_value=="5th-Bottom quintile" ~ "5 - lowest income",
+                                 TRUE ~ split_value)) %>%
+  filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
+  
+  # keep the required columns
+  select(code, ind = `Scottish Health Survey Indicator`, trend_axis, split_name, split_value, stat, value = Value) %>%
+  
+  # reshape to wide
+  pivot_wider(names_from=stat, values_from = value) %>%
+  
+  # add def_period column
+  # first need to calculate the difference (year_diff) between the first and last year in the trend_axis to work out what def_period to add
+  # this calc copes with single year (e.g. year_diff for 2008 = 0), two years (year_diff for 2010-2011 = 1),
+  # and the aggregates used for lower geogs (year_diff = 3 if not including 2020, or 4 if 2020 is in the range, because 2020 data are excluded)
+  mutate(year_diff =
+           as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
+         - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
+  mutate(year = case_when(year_diff <= 1 ~ as.numeric(substr(trend_axis, 1, 4)), # year = first/only year in the label
+                          year_diff>1 ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
+  mutate(def_period = ifelse(year_diff <= 1,
+                             paste0("Survey year (", trend_axis, ")"),
+                             paste0("Aggregated survey years (", trend_axis, ")"))) %>%
+  mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
+         sex = "Total")
+
+
+### 3. Which indicators should be kept? ----
+
+# print out list of all available indicators in the data:
+unique(shes_df$ind)
+# look through to check which ones we need to keep
+
+# # check LLTI data:
+# # there are 2 similarly-named indicators for LLTI.
+# # they have overlapping temporal coverage, so need to look at the splits, geographies, and year-ranges involved
+# llti <- shes_df %>%
+#   filter(ind %in% c("Long-term conditions: Limiting long-term conditions",
+#                     "Long-term illness: Limiting long-term illness")) %>%
+#   mutate(geog = substr(code, 1, 3)) %>%
+#   select(ind, split_name, geog, year_diff) %>%
 #   unique() %>%
-#   merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis"), all.y=TRUE)
-# 
-# shes_df <- shes_df %>%
-#   rbind(totals_to_add)
+#   pivot_wider(names_from = split_name, values_from = year_diff)
+# # Conclusion: "Long-term conditions" is the one to keep, "Long-term illness" just available for annual Scotland data, for fewer years than the LT conditions data.
+
+# List all the indicators we want to keep:
+keep_all <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)
+          "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)
+          "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)
+          "Food insecurity (worried would run out of food): Yes",  # 99105
+          "Healthy weight: Healthy weight" #99106
+          )
+
+keep_only_ca <- c("Summary activity levels: Meets recommendations",  #99107
+                  "Self-assessed general health: Very good/Good",    # 99108
+                  "Fruit & vegetable consumption: 5 portions or more",  #30013
+                  "Mental wellbeing", # 30001 (mean score, as in the indicator definition)
+                  "General health questionnaire (GHQ-12): Score 4+", # 30003
+                  "Long-term conditions: Limiting long-term conditions") # 99109
+
+# keep the required indicators
+shes_keep_all <- shes_df %>%
+  filter(ind %in% keep_all) 
+shes_keep_ca <- shes_df %>%
+  filter(ind %in% keep_only_ca & substr(code, 1, 3) == "S12")
+
+### 4. Further processing:  ----
+
+shes_df <- rbind(shes_keep_all, shes_keep_ca) %>%
+  
+  # Add shorter indicator name column (used as filename)
+  mutate(indicator = case_when(ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",
+                               ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",
+                               ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
+                               ind == "Food insecurity (worried would run out of food): Yes" ~ "food_insecurity",
+                               ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",
+                               ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",
+                               ind == "Mental wellbeing" ~ "mental_wellbeing",
+                               ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
+                               ind == "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" ~ "meets_mvpa_and_strength_recs",
+                               ind == "Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" ~ "binge_drinking",
+                               ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
+                               ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units"),
+         # Create new ind_id column
+         ind_id = case_when(indicator == "self_assessed_health" ~ 99108,
+                            indicator == "limiting_long_term_condition" ~ 99109,
+                            indicator == "healthy_weight" ~ 99106,
+                            indicator == "food_insecurity" ~ 99105,
+                            indicator == "fruit_veg_consumption" ~ 30013,
+                            indicator == "common_mh_probs" ~ 30003,
+                            indicator == "mental_wellbeing" ~ 30001,
+                            indicator == "physical_activity" ~ 99107,
+                            indicator == "meets_mvpa_and_strength_recs" ~ 14001,
+                            indicator == "binge_drinking" ~ 4170,
+                            indicator == "problem_drinker" ~ 4171,
+                            indicator == "weekly_alc_units" ~ 4172)) %>%
+  
+  # Select relevant columns
+  select(ind_id, indicator, code, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator)
+
+### Healthy weight: no aggregated Scot data since 2016-19 despite having annual data to 2023, so calculate those here:
+healthy_weight_roll_means <- shes_df %>%
+  filter(ind_id == 99106 & code == "S00000001" & trend_axis %in% c("2017", "2018", "2019", "2021", "2022", "2023")) %>%
+  select(-trend_axis, -def_period) %>%
+  group_by(ind_id, indicator, code, sex, split_name, split_value) %>%
+  arrange(year, .by_group = TRUE) %>%
+  mutate(rate = roll_mean(rate, n=4, align="center", fill = NA),
+         lowci = roll_mean(lowci, n=4, align="center", fill = NA),
+         upci = roll_mean(upci, n=4, align="center", fill = NA),
+         numerator = as.logical(NA)) %>%
+  ungroup %>%
+  filter(!is.na(rate)) %>%
+  mutate(year = year+1) %>%
+  mutate(trend_axis = case_when(year==2019 ~ "2017-2021",
+                                year==2020 ~ "2018-2022",
+                                year==2022 ~ "2019-2023",
+                                TRUE ~ as.character(NA))) %>%
+  mutate(def_period = paste0("Aggregated survey years (", trend_axis, ")"))
+  
+shes_df <- rbind(shes_df, healthy_weight_roll_means)
+
+### 5. Add totals for the popgroup and SIMD splits ----
+# (some have totals but some don't...)
+
+# Get split_value = "Total" for the splits without totals.
+# This is needed for subsequent calculation of the inequalities metrics, and is nice-to-have for the popgroup data:
+splits_w_no_total <- shes_df %>%
+  group_by(indicator, split_name) %>%
+  mutate(has_total = "Total" %in% split_value) %>%
+  ungroup() %>%
+  filter(has_total==FALSE) %>%
+  select(code, indicator, ind_id, trend_axis, year, def_period, sex, split_name) %>%
+  unique()
+
+totals_to_add <- shes_df %>%
+  filter(split_value=="Total") %>%
+  select(code, indicator, trend_axis, split_value, rate, lowci, upci, numerator) %>%
+  unique() %>%
+  merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis"), all.y=TRUE)
+
+shes_df <- shes_df %>%
+  rbind(totals_to_add)
 
 
 ###------------------------------------------------------------------------------------------------
 ### Now add the UKDS data:
 # (and standardise the split_names and split_values)
 shes_df <- shes_from_ukds %>%
- # rbind(shes_df) %>%
+  rbind(shes_df) %>%
   mutate(split_name=case_when(split_name=="Long-term Illness" ~ "Long-term illness",
                               TRUE ~ split_name)) %>%
   # published data refers to long term 'conditions' but the this is used interchangeably with 'illness' in the reporting. Here we standardise these:
@@ -282,11 +291,11 @@ shes_df <- shes_from_ukds %>%
                                split_value %in% c("Limiting long-term conditions", "Non-limiting Long-term Illness") ~ "Non-limiting long-term illness",
                                TRUE ~ split_value))
 
-table(shes_df$ind_id, useNA="always") # 32 in total, no NA
-table(shes_df$indicator, useNA="always") # 32 in total, no NA
+table(shes_df$ind_id, useNA="always") # 37 in total, no NA
+table(shes_df$indicator, useNA="always") # 37 in total, no NA
 table(shes_df$code, useNA="always") # Scot, HB, no LA, no NA
-table(shes_df$trend_axis, useNA="always") # 2008 to 2023, single year and 4-y aggregates, no NA
-table(shes_df$def_period, useNA="always") # 2008 to 2023, single year and 4-y aggregates, no NA
+table(shes_df$trend_axis, useNA="always") # 2008 to 2024, single year and 4-y aggregates, no NA
+table(shes_df$def_period, useNA="always") # 2008 to 2024, single year and 4-y aggregates, no NA
 table(shes_df$sex, useNA="always") # M/F/total, no NA
 table(shes_df$split_name, useNA="always") # 5 different splits, no NA
 table(shes_df$split_value, useNA="always") # correct, no NA
@@ -321,17 +330,6 @@ indicators_w_lower_geogs <- availability %>%
 indicators_w_lower_geogs <- as.vector(indicators_w_lower_geogs$indicator)
 
 
-# ### TEMPORARY STEP: drop the indicators we're not publishing yet: the PA profile
-# 
-# # meeting_muscle_strengthening_recommendations  14001
-# # adults_very_low_activity                      14002
-# # children_very_low_activity                    14003
-# # children_participating_sport                  14006
-# # children_active_play                          14007
-# 
-# shes_df <- shes_df %>%
-#   filter(!(ind_id %in% c(14001, 14002, 14003, 14006, 14007)))
-# 
 
 ### 7. Prepare final files -----
 
@@ -366,10 +364,12 @@ prepare_final_files <- function(ind){
     mutate(split_value = factor(split_value, 
                                 levels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
                                            "16 to 64y", "65y and over", 
+                                           "16-24", "25-34","35-44","45-54","55-64","65-74","75+",
                                            "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
                                            "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"),
                                 labels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
                                            "16 to 64y", "65y and over", 
+                                           "16-24y", "25-34y","35-44y","45-54y","55-64y","65-74y","75y+",
                                            "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
                                            "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"))) %>%
     arrange(code, year, split_name, split_value)
@@ -395,7 +395,7 @@ prepare_final_files <- function(ind){
   age_under16y <- c(30130, 30129) # all children included in "child with a parent with..." indicators
   age_4to12y <- c(99117, 30170, 30172, 30173, 30174, 30175) # all SDQ indicators pertain to 4-12 y olds
   age_2to15y <- c(30111, 14003, 14006, 14007) # all child PA questions pertain to 2-15y olds
-
+  
   agegp_pop <- ifelse(ind %in% age_under16y, "depr_pop_under16",
                       ifelse(ind %in% age_4to12y, "depr_pop_4to12",
                              ifelse(ind %in% age_2to15y, "depr_pop_2to15", "depr_pop_16+"))) # default is adult (16+)  
@@ -508,7 +508,7 @@ run_qa(type = "deprivation", filename = "limiting_long_term_condition", test_fil
 run_qa(type = "deprivation", filename = "healthy_weight", test_file=FALSE)
 run_qa(type = "deprivation", filename = "food_insecurity", test_file=FALSE)
 run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file=FALSE)
-run_qa(type = "deprivation", filename = "common_mh_probs", test_file=FALSE)
+run_qa(type = "deprivation", filename = "common_mh_probs", test_file=FALSE) # no 2023 or 2024: why?
 run_qa(type = "deprivation", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "deprivation", filename = "physical_activity", test_file=FALSE)
 run_qa(type = "deprivation", filename = "binge_drinking", test_file=FALSE)
@@ -582,6 +582,7 @@ run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
 
 
 #END
+
 
 
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -293,7 +293,7 @@ shes_df <- shes_from_ukds %>%
 
 table(shes_df$ind_id, useNA="always") # 37 in total, no NA
 table(shes_df$indicator, useNA="always") # 37 in total, no NA
-table(shes_df$code, useNA="always") # Scot, HB, no LA, no NA
+table(shes_df$code, useNA="always") # Scot, HB, LA, no NA
 table(shes_df$trend_axis, useNA="always") # 2008 to 2024, single year and 4-y aggregates, no NA
 table(shes_df$def_period, useNA="always") # 2008 to 2024, single year and 4-y aggregates, no NA
 table(shes_df$sex, useNA="always") # M/F/total, no NA
@@ -329,6 +329,15 @@ indicators_w_lower_geogs <- availability %>%
   unique()
 indicators_w_lower_geogs <- as.vector(indicators_w_lower_geogs$indicator)
 
+# identify indicators where only sex==Total is available for HBs (so can exclude from popgroup file)
+inds_w_only_total_sex_hb <- shes_df %>%
+  filter(substr(code, 1, 3)=="S08") %>%
+  filter(split_name=="Sex") %>% 
+  group_by(indicator) %>%
+  summarise(female = sum(sex=="Female")) %>%
+  ungroup() %>%
+  filter(female==0)
+inds_w_only_total_sex_hb <- as.vector(inds_w_only_total_sex_hb$indicator)
 
 
 ### 7. Prepare final files -----
@@ -360,6 +369,8 @@ prepare_final_files <- function(ind){
     mutate(geog = substr(code, 1, 3)) %>%
     filter((geog=="S00" & str_detect(def_period, "Survey year ")) |  #select the un-aggregated data for Scotland
              (geog!="S00" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
+    {if (ind %in% inds_w_only_total_sex_hb) filter(., !(split_name=="Sex" & geog!="S00")) #drop the HB*Sex split if only has 'total'
+      else .} %>% # keep all data
     select(-indicator, -sex, -geog) %>%
     mutate(split_value = factor(split_value, 
                                 levels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
@@ -373,6 +384,9 @@ prepare_final_files <- function(ind){
                                            "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
                                            "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"))) %>%
     arrange(code, year, split_name, split_value)
+  
+  # drop if sex only == total (no M/F)
+  
   
   # Save
   write.csv(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
@@ -394,11 +408,13 @@ prepare_final_files <- function(ind){
   # get the right age groups for the inequalities calculation:
   age_under16y <- c(30130, 30129) # all children included in "child with a parent with..." indicators
   age_4to12y <- c(99117, 30170, 30172, 30173, 30174, 30175) # all SDQ indicators pertain to 4-12 y olds
-  age_2to15y <- c(30111, 14003, 14006, 14007) # all child PA questions pertain to 2-15y olds
+  age_5to15y <- c(14003, 14006, 14007) # these child PA indicators restricted to 5-15y olds
+  age_2to15y <- c(30111) # child PA >1hr pertains to 2-15y olds
   
   agegp_pop <- ifelse(ind %in% age_under16y, "depr_pop_under16",
                       ifelse(ind %in% age_4to12y, "depr_pop_4to12",
-                             ifelse(ind %in% age_2to15y, "depr_pop_2to15", "depr_pop_16+"))) # default is adult (16+)  
+                             ifelse(ind %in% age_2to15y, "depr_pop_2to15", 
+                                    ifelse(ind %in% age_5to15y, "depr_pop_5to15", "depr_pop_16+")))) # default is adult (16+)  
   
   # add population data (quintile level) so that inequalities can be calculated
   simd_data <-  simd_data|>

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -13,8 +13,9 @@
 # This script uses the data published on the SHeS dashboard https://scotland.shinyapps.io/sg-scottish-health-survey/ 
 # for the indicators that are published there (currently 21, as of May 2026, see below). 
 # (It can be easiest to request the published data direct from the SHeS team, scottishhealthsurvey@gov.scot) 
-# NB. Some indicators on their dashboard look similar but aren't defined/grouped in the way we need for ScotPHO indicators.
+# NB. Some indicators on their dashboard look similar but aren't defined/grouped in the way we want/need for ScotPHO indicators.
 
+## ADULTS (N=15)
 #### 4170:  Alcohol consumption: Binge drinking (drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" (previous indicator definition excluded non-drinkers from denom)
 #### 4171:  Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here)
 #### 4172:  Alcohol consumption (mean weekly units)
@@ -29,25 +30,30 @@
 #### 99107: Summary activity levels (ADULT) Percentage of adults who met the recommended moderate or vigorous physical activity guideline in the previous four weeks. In July 2011, the Chief Medical Officers of each of the four UK countries agreed and introduced revised guidelines on physical activity. Adults are recommended to accumulate 150 minutes of moderate activity or 75 minutes of vigorous activity per week, or an equivalent combination of both, in bouts of 10 minutes or more. The variable used was adt10gpTW. This bandings used for this variable include the new walking definition for those aged 65 years and over.
 #### 99108: Self-assessed health of adults (age 16+) Percentage of adults who, when asked "How good is your health in general?", selected "good" or "very good". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
 #### 99109: Limiting long-term conditions (age 16+) Percentage of adults who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
-#### 99121: Health risk behaviours
+#### 99121: Health risk behaviours (NO DATA EXTRACTED FROM UKDS DATA AS UNCLEAR HOW TO CODE)
+
+## CHILDREN (N=6)
 #### 30111: Children's PA guidelines:  % children meeting 1 hour PA per day (INCL. SCHOOL)
 #### 14003: Children with very low PA levels
 #### 14006: Children participating in sport
 #### 30114: Children's general health. Percentage of children who, when asked "How good is your health in general?", selected "good" or "excellent". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
 #### 30115: Children with Limiting long-term conditions.	Percentage of children who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
-#### 99144: Children at risk of obesity (2-15y) (Monica's indicator)
+#### 14012 % children meeting activity guidelines (NOT inc school) (var ch00sum7)
+
 
 #########################################################
 # STEP 2:
 #########################################################
 
-# Additional indicators (20 as of May 2026, listed below) can only be sourced from the UK Data Service (UKDS) microdata. 
+# Additional indicators (21 as of May 2026, listed below) can only be sourced from the UK Data Service (UKDS) microdata. 
 # The UKDS data are imported and processed in a separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# In that repo we calculate estimates for all available splits for all available indicators 
-# (including those available on the SHeS dashboard, listed above, as there could be additional splits that aren't published, 
-# despite being above the SHeS suppression threshold of denominators <30) 
+# In that repo we calculate estimates for all available splits for all available indicators, including those available on the SHeS dashboard (listed above), 
+# as there could be additional splits that aren't published, despite being above the SHeS suppression threshold of denominators <30). 
+# Suppression of splits below that threshold is done in the ScotPHO_survey_data ukds_shes_calcs.R script, 
+# and any splits where more than 25% of the estimates have to be suppressed are removed entirely 
+# (25% was an entirely arbitrary figure from Liz's head, which seemed reasonable at the time).
 
-##### ADULTS
+##### ADULTS (N=11)
 #### 30004 = depsymp	Percentage of adults who had a symptom score of two or more on the depression section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was depsymp (or dvg11 in 2008). 
 #### 30005 = anxsymp	Percentage of adults who had a symptom score of two or more on the anxiety section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was anxsymp (or dvj12 in 2008). 
 #### 30009 = suicide2	Percentage of adults who made an attempt to take their own life, by taking an overdose of tablets or in some other way, in the past year. The variable used was suicide2. 
@@ -59,7 +65,7 @@
 #### 30052 = work_bal	Mean score for how satisfied adults are with their work-life balance (paid work). Respondents were asked "How satisfied are you with the balance between the time you spend on your paid work and the time you spend on other aspects of your life?" on a scale between 0 (extremely dissatisfied) and 10 (extremely satisfied). The intervening scale points were numbered but not labelled. The variable was WorkBal. 
 #### 30053 = contrl	Percentage of adults who often or always have a choice in deciding how they do their work, in their current main job. The five possible responses ranged from "always" to "never". The variable was Contrl. 
 #### 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
-##### CHILDREN
+##### CHILDREN (N=10)
 #### 14007 - ch30plyg - Children engaging in active play
 #### 30129 = ch_audit  Percentage of children aged 15 years or under with a parent/carer who reports consuming alcohol at hazardous or harmful levels (AUDIT questionnaire score 8+)
 #### 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
@@ -69,19 +75,20 @@
 #### 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
 #### 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
 #### 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
+#### 99144: Children at risk of obesity (2-15y) (Monica's indicator: need to check how it compares with the data she's been provided with)
 
 #########################################################
 # STEP 3: 
 #########################################################
 
-### And adding data for a further 25 indicators (13 adult, 12 CYP) that have been processed in the ScotPHO_survey_data repo 
-### (raw data processing elsewhere because they use UK Data Service data)
-### (data for SIMD x sex are also added for the 7 published variables above that are in the adult MH profile (see *), as these can be derived from the UKDS data.)
-### (Mar 2026: stat.gov.scot data not published for 2024 yet, so will just use the additional geog - CA - for the indicators we get from UKDS)
+# Check availability of the indicators from these two sources.
+# Use the SHeS dashboard data wherever available.
+# Prep the final ScotPHO dashboard indicator files
 
 
-
-### functions/packages -----
+#########################################################
+### Functions/packages -----
+#########################################################
 
 source("functions/main_analysis.R") # for packages and QA
 source("functions/deprivation_analysis.R") # for packages and QA
@@ -90,14 +97,56 @@ library(arrow) # for parquet files
 ## SHeS folder
 shes_folder <- file.path(profiles_data_folder, "Received Data", "Scottish Health Survey")
 
-# Pre-processed UKDS data (UK data service)
+
+
+#########################################################
+### Read in the data -----
+#########################################################
+
+## Pre-processed UKDS data (UK data service)
 # The data read in below has been prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# Last updated May 2026 (SHeS data up to 2024)
+# Last updated June 2026 (SHeS data up to 2024)
 shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes_raw.rds")) %>%
-  mutate(code = as.character(code))
+  mutate(code = as.character(code)) %>%
+  mutate(source = "UKDS") %>%
+  mutate(areatype = case_when(substr(code, 1, 3)=="S00" ~ "Scot",
+                              substr(code, 1, 3)=="S08" ~ "HB",
+                              substr(code, 1, 3)=="S12" ~ "CA",
+                              substr(code, 1, 3)=="S11" ~ "ADP",
+                              substr(code, 1, 3)=="S32" ~ "PD",
+                              substr(code, 1, 3)=="S37" ~ "HSCP",
+                              TRUE ~ "NA")) %>%
+  # correct the equivalised income splits: (to be added to the survey data processing ultimately)
+  # NB. quintiles have opposite ordering to SIMD (to match SHeS dashboard)
+  ## NEED TO CHANGE THIS IN THE PROCESSING FILE CODE
+  mutate(split_value = case_when(split_name == "Income (equivalised)" & split_value == "Q1 (lowest)" ~ "Q5 (lowest income)",
+                                 split_name == "Income (equivalised)" & split_value == "Q5 (highest)" ~ "Q1 (highest income)",
+                                 TRUE ~ split_value))
 
 
+# which geogs do we want to keep/drop?
+# drop ADP and PD for PA profile indicators:
+pa_inds <- c(14001, 14002, 30111, 14003, 14006, 14007, 14012)
+shes_from_ukds <- shes_from_ukds %>%
+  filter(!(ind_id %in% pa_inds & areatype %in% c("PD", "ADP")))
 
+# make a lookup for ind_id
+ind_ids <- shes_from_ukds %>%
+  select(indicator, ind_id) %>%
+  unique()
+
+
+## SHeS dashboard data: 
+## Can be downloaded from there but easier to get direct from the SHeS team (see open_data_to_2024 folder)
+SHeS_SCOTLAND <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
+SHeS_LA <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_rank_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
+SHeS_SIMD <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_simd_opendata.xlsx")) %>% mutate(split_name = "Deprivation (SIMD)")
+SHeS_AGE <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_age_opendata.xlsx")) %>% mutate(split_name = "Age group")
+SHeS_INCOME <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_ei_opendata.xlsx")) %>% mutate(split_name = "Income (equivalised)")
+SHeS_CONDITIONS <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_ltc_opendata.xlsx")) %>% mutate(split_name = "Long-term Illness")
+
+
+## Alternative route to the published data: 
 # ### Do this if you need to extract the data from statistics.gov.scot (as of May 2026: not updated as quickly as the SHeS dashboard is) ---- 
 # Run lines below to install the opendata scotland package
 # devtools::install_github("ScotGovAnalysis/opendatascot",upgrade = "never",build_vignettes = TRUE)
@@ -120,9 +169,7 @@ shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes
 # # write_parquet(SHeS_INCOME, file.path(shes_folder, "SHeS_INCOME.parquet"))
 # # write_parquet(SHeS_CONDITIONS, file.path(shes_folder, "SHeS_LONGTERM_CONDITIONS.parquet"))
 # 
-# ### 1. Read in the downloaded and saved data ----
-# 
-# # Published data from statistics.gov.scot:
+# ### Read in the downloaded and saved data ----
 # SHeS_SCOTLAND <- read_parquet(file.path(shes_folder, "SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
 # SHeS_LA <- read_parquet(file.path(shes_folder, "SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
 # SHeS_SIMD <- read_parquet(file.path(shes_folder, "SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
@@ -130,21 +177,12 @@ shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes
 # SHeS_INCOME <- read_parquet(file.path(shes_folder, "SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
 # SHeS_CONDITIONS <- read_parquet(file.path(shes_folder, "SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
 
-## The dashboard data are more likely to be up to date: 
-## Obtained direct from the SHeS team (see open_data_2026 folder)
-SHeS_SCOTLAND <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
-SHeS_LA <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_rank_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
-SHeS_SIMD <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_simd_opendata.xlsx")) %>% mutate(split_name = "Deprivation (SIMD)")
-SHeS_AGE <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_age_opendata.xlsx")) %>% mutate(split_name = "Age")
-SHeS_INCOME <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_ei_opendata.xlsx")) %>% mutate(split_name = "Income (equivalised)")
-SHeS_CONDITIONS <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_ltc_opendata.xlsx")) %>% mutate(split_name = "Long-term illness")
 
+#########################################################
+### Process the published data -----
+#########################################################
 
-
-# Mar 2026: no 2024 data in the statistics.gov.scot data yet, so keep all from UKDS raw microdata (all years)
-###------------------------------------------------------------------------------------------------
-### PUBLISHED DATA PROCESSING:
-### 2. Combine data and get column data and formats right----
+### Combine data and get column data and formats right----
 shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
   bind_rows() %>% # append them together
   mutate(code = ifelse(GeographyCode=="S92000003", "S00000001", GeographyCode)) %>% # recode Scotland
@@ -155,17 +193,35 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
   # create a new split_value column: coalesce combines non-NA values into a single column
   mutate(split_value = coalesce(Age, Sex, LongtermConditions, EquivalisedIncome, SIMDquintiles)) %>% # this works because there is only ever one non-NA cell in these 5 columns
   mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
-  mutate(split_value = case_when(split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
-                                 split_value=="5 - least deprived" ~ "5",
-                                 split_value=="1st-Top quintile" ~ "1 - highest income", # match ScotPHO format
-                                 split_value=="2nd quintile" ~ "2",
-                                 split_value=="3rd quintile" ~ "3",
-                                 split_value=="4th quintile" ~ "4",
-                                 split_value=="5th-Bottom quintile" ~ "5 - lowest income",
-                                 TRUE ~ split_value)) %>%
-  #filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
-
-# keep the required columns
+  mutate(split_value = case_when(# Deprivation:
+    split_name == "Deprivation (SIMD)" & split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
+    split_name == "Deprivation (SIMD)" & split_value=="2nd quintile" ~ "2",
+    split_name == "Deprivation (SIMD)" & split_value=="3rd quintile" ~ "3",
+    split_name == "Deprivation (SIMD)" & split_value=="4th quintile" ~ "4",
+    split_name == "Deprivation (SIMD)" & split_value=="5 - least deprived" ~ "5",
+    # equivalised household income
+    split_name == "Income (equivalised)" & split_value=="1st-Top quintile" ~ "Q1 (highest income)", # match ScotPHO format
+    split_name == "Income (equivalised)" & split_value=="2nd quintile" ~ "Q2", 
+    split_name == "Income (equivalised)" & split_value=="3rd quintile" ~ "Q3", 
+    split_name == "Income (equivalised)" & split_value=="4th quintile" ~ "Q4", 
+    split_name == "Income (equivalised)" & split_value=="5th-Bottom quintile" ~ "Q5 (lowest income)",
+    # Age group:
+    split_name == "Age group" & split_value=="0-3" ~ "0 to 3y",
+    split_name == "Age group" & split_value=="11-12" ~ "11 to 12y",
+    split_name == "Age group" & split_value=="12-15" ~ "12 to 15y",
+    split_name == "Age group" & split_value=="13-15" ~ "13 to 15y",
+    split_name == "Age group" & split_value=="2-4" ~ "2 to 4y",
+    split_name == "Age group" & split_value=="4-7" ~ "4 to 7y",
+    split_name == "Age group" & split_value=="5-7" ~ "5 to 7y",
+    split_name == "Age group" & split_value=="8-10" ~ "8 to 10y",
+    split_name == "Age group" & split_value=="8-11" ~ "8 to 11y",
+    # long-term illness
+    split_name == "Long-term Illness" & split_value=="Limiting long-term conditions" ~ "Limiting Long-term Illness",
+    split_name == "Long-term Illness" & split_value=="No long-term conditions" ~ "No Long-term Illness",
+    split_name == "Long-term Illness" & split_value=="Non-limiting long-term conditions" ~ "Non-limiting Long-term Illness",
+    TRUE ~ split_value)) %>%
+  
+  # keep the required columns
   select(code, ind = ScottishHealthSurveyIndicator, trend_axis, split_name, split_value, stat, value = Value) %>%
   
   # reshape to wide
@@ -178,7 +234,7 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
   mutate(year_diff =
            as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
          - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
-  filter(year_diff!=1) %>% #drop the two-year aggregates
+  filter(year_diff!=1) %>% #drop the two-year aggregates: we don't present these
   mutate(year = case_when(year_diff == 0 ~ as.numeric(substr(trend_axis, 1, 4)), # only one year in the label
                           year_diff %in% c(3:4) ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
   mutate(def_period = ifelse(year_diff==0,
@@ -186,282 +242,194 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
                              paste0("Aggregated survey years (", trend_axis, ")"))) %>%
   mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
          sex = case_when(split_name=="Sex" ~ split_value,
-                         TRUE ~ "Total"))
+                         TRUE ~ "Total")) %>%
+  # identify the areatype
+  mutate(areatype = case_when(substr(code, 1, 3)=="S00" ~ "Scot",
+                              substr(code, 1, 3)=="S08" ~ "HB",
+                              substr(code, 1, 3)=="S12" ~ "CA",
+                              TRUE ~ "NA")) 
 
 
-### 3. Which indicators should be kept? ----
+### Which published indicators should be kept? ----
 
 # print out list of all available indicators in the data:
 unique(shes_from_dashboard$ind)
 # look through to check which ones we need to keep
 
 # List all the indicators we want to keep:
-# keep_all <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)
-#           "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)
-#           "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)
-#           "Food insecurity (worried would run out of food): Yes",  # 99105
-#           "Healthy weight: Healthy weight" #99106
-#           )
-# 
-# keep_only_ca <- c("Summary activity levels: Meets recommendations",  #99107
-#                   "Self-assessed general health: Very good/Good",    # 99108
-#                   "Fruit & vegetable consumption: 5 portions or more",  #30013
-#                   "Mental wellbeing", # 30001 (mean score, as in the indicator definition)
-#                   "General health questionnaire (GHQ-12): Score 4+", # 30003
-#                   "Long-term conditions: Limiting long-term conditions") # 99109
-
 dashboard_vars_to_keep <- c("Alcohol consumption: Hazardous/Harmful drinker",                                                                               
                             "Alcohol consumption (mean weekly units)",                                                                                      
                             "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women",                             
-                            "Healthy weight: Healthy weight",                                                                                               
                             "Fruit & vegetable consumption: 5 portions or more",                                                                            
-                            "Worried would run out of food: Yes",                                                                                           
+                            "General health questionnaire (GHQ-12): Score 4+",                                                                              
+                            "Healthy weight: Healthy weight",                                                                                               
                             "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)",                                                              
-                            "Self-assessed general health: Very good/Good",                                                                                 
-                            "Self-assessed general health (children): Very good/Good",                                                                      
                             "Long-term conditions: Limiting long-term conditions",                                                                          
                             "Long-term conditions (children): Limiting long-term conditions",                                                               
-                            "General health questionnaire (GHQ-12): Score 4+",                                                                              
+                            "Mental wellbeing",                                                                                           
+                            "Multiple risks for poor health: Two or more",
                             "Participating in sport (children): Yes",                                                                                       
+                            "Self-assessed general health: Very good/Good",                                                                                 
+                            "Self-assessed general health (children): Very good/Good",                                                                      
                             "Summary activity levels: Meets recommendations", 
                             "Summary activity levels: Very low activity",
                             "Summary activity levels (including school) (children): Meets recommendations",                                                 
-                            "Summary activity levels (including school) (children): Low activity",                                                          
+                            "Summary activity levels (including school) (children): Low activity",  
+                            "Summary activity levels (excluding school) (children): Meets recommendations",
                             "Whether meets muscle strengthening recommendations: Yes",                                                                      
-                            "Mental wellbeing")                                                                                                             
-
-dashboard_vars_to_keep <- c(,                                                                               
-                            ,                                                                                      
-                            ,                             
-                            ,                                                                                               
-                            ,                                                                            
-                            ,                                                                                           
-                            ,                                                              
-                            ,                                                                                 
-                            "Self-assessed general health (children): Very good/Good",                                                                      
-                            ,                                                                          
-                            "Long-term conditions (children): Limiting long-term conditions",                                                               
-                            ,                                                                              
-                            ,                                                                                       
-                            , 
-                            ,
-                            ,                                                 
-                            ,                                                          
-                            ,                                                                      
-                            )    
-# involve...
-
-
-
-shes_from_dashboard <- shes_from_dashboard %>%
-  mutate(indicator = case_when( ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",    
-                                ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",  
-                                ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",  
-                                ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
-                                ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",  
-                                ind == "Mental wellbeing" ~ "mental_wellbeing",    
-                                ind == "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)" ~ "life_satisfaction",  
-                                ind == "Summary activity levels (including school) (children): Meets recommendations" ~ "cyp_pa_over_1h_per_day",
-                                ind == "Summary activity levels: Very low activity" ~ "adults_very_low_activity",    
-                                ind == "Whether meets muscle strengthening recommendations: Yes" ~ "meeting_muscle_strengthening_recommendations",
-                                ind == "Summary activity levels (including school) (children): Low activity" ~ "children_very_low_activity",
-                                ind == "Participating in sport (children): Yes" ~ "children_participating_sport",
-                                ind == "Healthy weight: Healthy weight" ~ "adult_healthy_weight",
-                                ind == "Worried would run out of food: Yes" ~ "food_insecurity",
-                                ind == "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women" ~ "alc_binge_drinking",
-                                ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "haz_or_harmful_drinker",
-                                ind == "Alcohol consumption (mean weekly units)" ~ "alc_consumption_units",
-                                TRUE ~ as.character(NA)  )) %>%
-  indicator == "gh_qg2" ~ "common_mh_probs",    
-indicator == "gen_helf" ~ "self_assessed_health",  
-indicator == "limitill2" ~ "limiting_long_term_condition",  
-indicator == "adt10gp_tw2" ~ "physical_activity",
-indicator == "porftvg3" ~ "fruit_veg_consumption",  
-indicator == "rg17a_new" ~ "unpaid_caring", 
-indicator == "wemwbs" ~ "mental_wellbeing",    
-indicator == "lifesat2" ~ "life_satisfaction",  
-indicator == "cghq214" ~ "cyp_parent_w_ghq4",    
-indicator == "ch_audit" ~ "cyp_parent_w_harmful_alc",
-indicator == "involve" ~ "involved_locally",  
-indicator == "p_crisis" ~ "support_network", 
-indicator == "str_work2" ~ "stress_at_work",
-indicator == "contrl" ~ "choice_at_work",   
-indicator == "support1" ~ "line_manager", 
-indicator == "depsymp" ~ "depression_symptoms",  
-indicator == "anxsymp" ~ "anxiety_symptoms",  
-indicator == "dsh5sc" ~ "deliberate_selfharm",   
-indicator == "suicide2" ~ "attempted_suicide",
-indicator == "work_bal" ~ "work-life_balance",
-indicator == "sdq_totg" ~ "cyp_sdq_totaldiffs",
-indicator == "childpa1hr" ~ "cyp_pa_over_1h_per_day",
-indicator == "sdq_totg" ~ "cyp_sdq_totaldiffs",
-indicator == "sdq_peeg" ~ "cyp_sdq_peer",
-indicator == "sdq_cong" ~ "cyp_sdq_conduct",
-indicator == "sdq_hypg" ~ "cyp_sdq_hyperactivity",
-indicator == "sdq_emog" ~ "cyp_sdq_emotional",
-indicator == "sdq_pro" ~ "cyp_sdq_prosocial",
-indicator == "adt10gp_tw_LOW" ~ "adults_very_low_activity",    
-indicator == "mus_rec" ~ "meeting_muscle_strengthening_recommendations",
-indicator == "c00sum7s" ~ "children_very_low_activity",
-indicator == "spt1ch" ~ "children_participating_sport",
-indicator == "ch30plyg" ~ "children_active_play",
-indicator == "healthyweight" ~ "adult_healthy_weight",
-indicator == "foodinsecure" ~ "food_insecurity",
-indicator == "binge" ~ "alc_binge_drinking",
-indicator == "hazharmful" ~ "haz_or_harmful_drinker",
-indicator == "drating" ~ "alc_consumption_units",
-indicator == "cbmig5_new" ~ "child_obesity_risk",
-indicator == "child_gen_helf" ~ "child_general_health",
-indicator == "child_limitill2" ~ "child_llti",
-
-# keep the required indicators
-shes_keep_all <- shes_df %>%
-  filter(ind %in% keep_all) 
-shes_keep_ca <- shes_df %>%
-  filter(ind %in% keep_only_ca & substr(code, 1, 3) == "S12")
+                            "Worried would run out of food: Yes"   )                                                                                                             
 
 shes_from_dashboard <- shes_from_dashboard %>%
   filter(ind %in% dashboard_vars_to_keep) %>%
-  
-
-### 4. Further processing:  ----
-
-shes_df <- rbind(shes_keep_all, shes_keep_ca) %>%
-  
-  # Add shorter indicator name column (used as filename)
-  mutate(indicator = case_when(ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",
-                               ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",
-                               ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
-                               ind == "Food insecurity (worried would run out of food): Yes" ~ "food_insecurity",
-                               ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",
-                               ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",
-                               ind == "Mental wellbeing" ~ "mental_wellbeing",
-                               ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
-                               ind == "Whether meets MVPA & muscle strengthening recommendations: Meets MVPA & muscle strengthening recommendations" ~ "meets_mvpa_and_strength_recs",
-                               ind == "Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" ~ "binge_drinking",
-                               ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
-                               ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units"),
-         # Create new ind_id column
-         ind_id = case_when(indicator == "self_assessed_health" ~ 99108,
-                            indicator == "limiting_long_term_condition" ~ 99109,
-                            indicator == "healthy_weight" ~ 99106,
-                            indicator == "food_insecurity" ~ 99105,
-                            indicator == "fruit_veg_consumption" ~ 30013,
-                            indicator == "common_mh_probs" ~ 30003,
-                            indicator == "mental_wellbeing" ~ 30001,
-                            indicator == "physical_activity" ~ 99107,
-                            indicator == "meets_mvpa_and_strength_recs" ~ 14001,
-                            indicator == "binge_drinking" ~ 4170,
-                            indicator == "problem_drinker" ~ 4171,
-                            indicator == "weekly_alc_units" ~ 4172)) %>%
-  
+  # add indicator names to match the UKDS data
+  mutate(indicator = case_when( ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "haz_or_harmful_drinker",
+                                ind == "Alcohol consumption (mean weekly units)" ~ "alc_consumption_units",
+                                ind == "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women" ~ "alc_binge_drinking",
+                                ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",  
+                                ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",    
+                                ind == "Healthy weight: Healthy weight" ~ "adult_healthy_weight",
+                                ind == "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)" ~ "life_satisfaction",  
+                                ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",  
+                                ind == "Long-term conditions (children): Limiting long-term conditions" ~ "child_llti",
+                                ind == "Mental wellbeing" ~ "mental_wellbeing",    
+                                ind == "Multiple risks for poor health: Two or more" ~ "multi_health_risks", 
+                                ind == "Participating in sport (children): Yes" ~ "children_participating_sport",
+                                ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",  
+                                ind == "Self-assessed general health (children): Very good/Good" ~ "child_general_health",
+                                ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
+                                ind == "Summary activity levels: Very low activity" ~ "adults_very_low_activity",    
+                                ind == "Summary activity levels (including school) (children): Meets recommendations" ~ "cyp_pa_over_1h_per_day",
+                                ind == "Summary activity levels (including school) (children): Low activity" ~ "children_very_low_activity",
+                                ind == "Summary activity levels (excluding school) (children): Meets recommendations" ~ "children_meet_pa_recs_excl_school",
+                                ind == "Whether meets muscle strengthening recommendations: Yes" ~ "meeting_muscle_strengthening_recommendations",
+                                ind == "Worried would run out of food: Yes" ~ "food_insecurity",
+                                TRUE ~ as.character(NA)  )) %>%
+  # Add ind_id column using lookup created above
+  merge(y=ind_ids, by="indicator", all.x=TRUE) %>%
+  mutate(ind_id = ifelse(indicator=="multi_health_risks", 99121, ind_id)) %>% #this indicator is not in UKDS data, so add its ind_id manually
   # Select relevant columns
-  select(ind_id, indicator, code, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator)
+  select(ind_id, indicator, code, areatype, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator) 
 
-### Healthy weight: no aggregated Scot data since 2016-19 despite having annual data to 2023, so calculate those here:
-healthy_weight_roll_means <- shes_df %>%
-  filter(ind_id == 99106 & code == "S00000001" & trend_axis %in% c("2017", "2018", "2019", "2021", "2022", "2023")) %>%
-  select(-trend_axis, -def_period) %>%
-  group_by(ind_id, indicator, code, sex, split_name, split_value) %>%
-  arrange(year, .by_group = TRUE) %>%
-  mutate(rate = roll_mean(rate, n=4, align="center", fill = NA),
-         lowci = roll_mean(lowci, n=4, align="center", fill = NA),
-         upci = roll_mean(upci, n=4, align="center", fill = NA),
-         numerator = as.logical(NA)) %>%
-  ungroup %>%
-  filter(!is.na(rate)) %>%
-  mutate(year = year+1) %>%
-  mutate(trend_axis = case_when(year==2019 ~ "2017-2021",
-                                year==2020 ~ "2018-2022",
-                                year==2022 ~ "2019-2023",
-                                TRUE ~ as.character(NA))) %>%
-  mutate(def_period = paste0("Aggregated survey years (", trend_axis, ")"))
-  
-shes_df <- rbind(shes_df, healthy_weight_roll_means)
+# which indicator ids?
+inds_in_db <- shes_from_dashboard$ind_id %>% unique() #n=21
 
-### 5. Add totals for the popgroup and SIMD splits ----
-# (some have totals but some don't...)
-
-# Get split_value = "Total" for the splits without totals.
+### Add totals for the popgroup and SIMD splits ----
 # This is needed for subsequent calculation of the inequalities metrics, and is nice-to-have for the popgroup data:
-splits_w_no_total <- shes_df %>%
+# Add split_value = "Total" for the splits without totals.
+
+# 1st Find the splits without totals:
+splits_w_no_total <- shes_from_dashboard %>%
   group_by(indicator, split_name) %>%
   mutate(has_total = "Total" %in% split_value) %>%
   ungroup() %>%
   filter(has_total==FALSE) %>%
-  select(code, indicator, ind_id, trend_axis, year, def_period, sex, split_name) %>%
+  select(code, indicator, ind_id, trend_axis, year, def_period, sex, split_name, areatype) %>%
   unique()
 
-totals_to_add <- shes_df %>%
+# 2nd Get the totals for those splits
+totals_to_add <- shes_from_dashboard %>%
   filter(split_value=="Total") %>%
-  select(code, indicator, trend_axis, split_value, rate, lowci, upci, numerator) %>%
+  select(code, indicator, trend_axis, split_value, rate, lowci, upci, numerator, areatype) %>%
   unique() %>%
-  merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis"), all.y=TRUE)
+  merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis", "areatype"), all.y=TRUE)
 
-shes_df <- shes_df %>%
-  rbind(totals_to_add)
+shes_from_dashboard <- shes_from_dashboard %>%
+  rbind(totals_to_add) %>%
+  mutate(source="dashboard")
+
+#########################################################
+### Compare availability -----
+#########################################################
+
+#indicators with different age groups to the dashboard data:
+# = adult low activity, adult meet muscle recs, child v low PA, child sport, child meets recs (incl school), child meets recs (excl school)
+pa_inds_agegp <- c(14001, 14002, 14006, 14003, 30111, 14012)
+# remove the dashboard age group splits for these indicators
+
+source_comparison <- shes_from_dashboard %>%
+  filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>%
+  filter(!split_name=="Long-term Illness") %>% # we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
+  merge(y=shes_from_ukds, by=c("indicator", "ind_id", "code", "areatype", "year", "trend_axis", "def_period", "sex", "split_name", "split_value"), all=TRUE) %>%
+  filter(areatype %in% c("Scot", "HB", "CA") & ind_id %in% inds_in_db) %>% # UKDS provides any PD, HSCP or ADP splits, as these aren't available in the dashboard. 
+  mutate(final_source = ifelse(is.na(source.x), source.y, source.x))
+
+# This comparison is limited to the indicators that are available from both sources (n=20 as of June 2026).
+# Another 21 (as of June 2026) are only available from the UKDS extract. One is only available from the dashboard data.
+ftable(source_comparison$indicator, 
+       source_comparison$split_name, 
+       source_comparison$final_source, 
+       source_comparison$areatype, 
+       row.vars=c(1:2))
+
+# Key points about the two sources:
+## Aggregated UKDS data start from 2008-11, while the aggregated dashboard data starts at 2012-15. 
+## Single year data start at 2008 for both sources
+## Dashboard only presents single year data for Scotland...
+## We want Scotland figures for aggregate years too, for plotting against lower geogs: so any aggregated Scotland data present in the UKDS extract will be used too. 
+## Dashboard only presents lower geogs for adult indicators (total, male, female) but no child indicators.
+## Dashboard presents all splits (except adult indicators by sex) for Scotland only, no lower geogs.
+## UKDS data have been processed for splits where less than 25% of the data need suppression. This means up to 1 in 4 data points could be suppressed for some splits.
+## Dashboard data don't provide numerators. Numerators from the UKDS processing will be used where available. 
+## UKDS provides SIMD splits by sex, dashboard doesn't.
+## UKDS provides urban/rural splits, while dashboard doesn't
+
+# additionals for deprivation = splits by sex, + aggregate years and lower geogs
+# additionals for age group = aggregate years + lower geogs
+# additionals for equiv invome = aggregate years + lower geogs
+# additionals for sex = earlier aggregate data
 
 
-###------------------------------------------------------------------------------------------------
-### Now add the UKDS data:
-# (and standardise the split_names and split_values)
-shes_df <- shes_from_ukds %>%
-  rbind(shes_df) %>%
-  mutate(split_name=case_when(split_name=="Long-term Illness" ~ "Long-term illness",
-                              TRUE ~ split_name)) %>%
-  # published data refers to long term 'conditions' but the this is used interchangeably with 'illness' in the reporting. Here we standardise these:
-  mutate(split_value=case_when(split_value %in% c("No long-term conditions", "No Long-term Illness") ~ "No long-term illness",
-                               split_value %in% c("Non-limiting long-term conditions", "Limiting Long-term Illness") ~ "Limiting long-term illness",
-                               split_value %in% c("Limiting long-term conditions", "Non-limiting Long-term Illness") ~ "Non-limiting long-term illness",
-                               TRUE ~ split_value))
 
-table(shes_df$ind_id, useNA="always") # 37 in total, no NA
-table(shes_df$indicator, useNA="always") # 37 in total, no NA
-table(shes_df$code, useNA="always") # Scot, HB, LA, no NA
-table(shes_df$trend_axis, useNA="always") # 2008 to 2024, single year and 4-y aggregates, no NA
-table(shes_df$def_period, useNA="always") # 2008 to 2024, single year and 4-y aggregates, no NA
-table(shes_df$sex, useNA="always") # M/F/total, no NA
-table(shes_df$split_name, useNA="always") # 5 different splits, no NA
-table(shes_df$split_value, useNA="always") # correct, no NA
+# keep UKDS where available
+shes_combined <- shes_from_dashboard %>%
+  filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>%
+  filter(!split_name=="Long-term Illness") %>% # we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
+  merge(y=shes_from_ukds, by=c("indicator", "ind_id", "split_name", "split_value", "sex", "code", "areatype", "trend_axis", "year", "def_period"), all=TRUE) %>%
+  # .x is dashboard, .y is ukds, so we keep dashboard for Scotland, where available
+  # opted to take lower geog data from UKDS processing, rather than dashboard data (even when available), so that all coincident geographies have the same data.
+  mutate(rate = ifelse(areatype=="Scot" & !is.na(rate.x), rate.x, rate.y), 
+         lowci = ifelse(areatype=="Scot" & !is.na(rate.x), lowci.x, lowci.y),
+         upci = ifelse(areatype=="Scot" & !is.na(rate.x), upci.x, upci.y),
+         numerator = numerator.y, # there are no numerators in the dashboard extract
+         source = ifelse(areatype=="Scot" & !is.na(rate.x), source.x, source.y)) %>%
+  mutate(rate_diff = case_when(!is.na(rate.x) & !is.na(rate.y) ~ rate.x-rate.y, 
+                               TRUE ~ as.numeric(NA)))
+#shes_from_dashboard has 25,693 records
+#shes_from_ukds has 612,347 records
+#shes_combined has 614,689 records
 
-
-
-
+# how do the indicator values compare?
+shes_combined %>% 
+  filter(!is.na(rate.x) & !is.na(rate.y)) %>%
+  ggplot() +
+  geom_point(aes(x=rate.x, y=rate.y)) +
+  facet_wrap(~indicator)
+# SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
+# SLIGHT DISCREPANCIES APPARENT THAT PROBABLY ARISE FROM THE UKDS DATA BEING A MORE SUPPRESSED VERSION OF THE RAW DATA THE SHES TEAM USE
 
 ### 6. Check geographical availability: ----
 
-# which Scotland-wide data to keep to match any lower geographies in the main_data (for trend chart and rank comparisons)?
-availability <- shes_df %>%
-  mutate(geog = substr(code, 1, 3),
-         years = case_when(nchar(trend_axis)==4 ~ "single",
+# which Scotland-wide data to keep to match any lower geographies in the main_data (needed for trend chart and rank comparisons)?
+availability <- shes_combined %>%
+  mutate(years = case_when(nchar(trend_axis)==4 ~ "single",
                            nchar(trend_axis)>4 ~ "aggregated",
                            TRUE ~ as.character(NA))) %>%
   filter(split_value=="Total") %>%
-  select(ind_id, indicator, geog, years, split_name) %>%
+  select(ind_id, indicator, areatype, years, split_name) %>%
   unique() %>%
-  group_by(ind_id, indicator, geog, split_name) %>%
+  group_by(ind_id, indicator, areatype, split_name) %>%
   summarise(count = n()) %>% # whether available for single/aggregated years only (count == 1), or both (count==2)
   ungroup()
-ftable(availability$indicator, availability$geog, availability$split_name, availability$count)
+ftable(availability$indicator, availability$areatype, availability$split_name, availability$count)
 # shows some splits are available at two levels of temporal aggregation: single year and 4y
 # main_data needs to select data at the level of aggregation of any lower geographies, if present, so that trend charts use the same trend_axis labels
 
 # make a list of the indicators this affects:
 indicators_w_lower_geogs <- availability %>%
-  filter(!geog=="S00") %>%
+  filter(!areatype=="Scot") %>%
   select(indicator) %>%
   unique()
 indicators_w_lower_geogs <- as.vector(indicators_w_lower_geogs$indicator)
-
-# identify indicators where only sex==Total is available for HBs (so can exclude from popgroup file)
-inds_w_only_total_sex_hb <- shes_df %>%
-  filter(substr(code, 1, 3)=="S08") %>%
-  filter(split_name=="Sex") %>% 
-  group_by(indicator) %>%
-  summarise(female = sum(sex=="Female")) %>%
-  ungroup() %>%
-  filter(female==0)
-inds_w_only_total_sex_hb <- as.vector(inds_w_only_total_sex_hb$indicator)
 
 
 ### 7. Prepare final files -----
@@ -470,14 +438,15 @@ inds_w_only_total_sex_hb <- as.vector(inds_w_only_total_sex_hb$indicator)
 prepare_final_files <- function(ind){
   
   # 1 - main data (ie data behind summary/trend/rank tab)
-  # Contains Scotland, LA and HB data (4-year aggregate)
-  main_data_final <- shes_df %>% 
+  # Contains Scotland and lower geogs
+  main_data_final <- shes_combined %>% 
     filter(indicator == ind,
            split_name == "Sex",
            split_value == "Total") %>%
+    # if lower geogs are present (4-y aggregated data only), the 4-y aggregated data should be selected for Scotland too, so that both can be plotted and compared
     {if (ind %in% indicators_w_lower_geogs) filter(., str_detect(def_period, "Aggregated")) #select the aggregated data
       else filter(., str_detect(def_period, "Survey year "))} %>% # select the un-aggregated data
-    select(!c(split_name, split_value, indicator, sex)) %>% 
+    select(ind_id, year, code, numerator, rate, upci, lowci, trend_axis, def_period) %>%
     unique() %>%
     arrange(code, year)
   
@@ -485,41 +454,37 @@ prepare_final_files <- function(ind){
   write_rds(main_data_final, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny.rds"))
   
   # 2 - population groups data (i.e. data behind population groups tab)
-  # Contains LA/HB data by sex (3 or 4-year aggregate) and Scotland data by sex/age/condition/income/simd (single year)
-  # Can use single year and aggregated data in the popgrp tab (as will only be comparing across data with the same time period: single year (all splits x Scotland) or aggregated (sex x lower geogs))
-  pop_grp_data <- shes_df %>% 
+  # Contains single year Scotland data and lower geog aggregated data 
+  # Can use single year and aggregated data in the popgrp tab (as will only ever be comparing across data with the same geog)
+  pop_grp_data <- shes_combined %>% 
     filter(indicator == ind) %>% 
     filter(split_name!="Deprivation (SIMD)") %>%
-    mutate(geog = substr(code, 1, 3)) %>%
-    filter((geog=="S00" & str_detect(def_period, "Survey year ")) |  #select the un-aggregated data for Scotland
-             (geog!="S00" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
-    {if (ind %in% inds_w_only_total_sex_hb) filter(., !(split_name=="Sex" & geog!="S00")) #drop the HB*Sex split if only has 'total'
-      else .} %>% # keep all data
-    select(-indicator, -sex, -geog) %>%
+    filter((areatype=="Scot" & str_detect(def_period, "Survey year ")) |  #select the un-aggregated data for Scotland
+             (areatype!="Scot" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
+    select(ind_id, year, code, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
     mutate(split_value = factor(split_value, 
                                 levels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
                                            "16 to 64y", "65y and over", 
                                            "16-24", "25-34","35-44","45-54","55-64","65-74","75+",
                                            "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
-                                           "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"),
+                                           "No long-term illness", "Long-term illness"),
                                 labels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
                                            "16 to 64y", "65y and over", 
                                            "16-24y", "25-34y","35-44y","45-54y","55-64y","65-74y","75y+",
                                            "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
-                                           "No long-term illness", "Non-limiting long-term illness","Limiting long-term illness"))) %>%
+                                           "No long-term illness", "Long-term illness"))) %>%
     arrange(code, year, split_name, split_value)
-  
-  # drop if sex only == total (no M/F)
-  
   
   # Save
   write.csv(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
   write_rds(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.rds"))
   
   # Process SIMD data
-  simd_data <- shes_df %>% 
+  simd_data <- shes_combined %>% 
     filter(indicator == ind) %>% 
-    filter(split_name=="Deprivation (SIMD)" & str_detect(def_period, "Survey year ")) %>%
+    filter(split_name=="Deprivation (SIMD)") %>%
+    filter(!(areatype=="Scot" & str_detect(def_period, "Aggregated "))) %>% # for Scotland data, keep only the single year data
+    select(ind_id, year, code, sex, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
     rename(quintile = split_value) %>%
     mutate(quint_type="sc_quin") %>%
     select(-split_name) %>%
@@ -532,7 +497,7 @@ prepare_final_files <- function(ind){
   # get the right age groups for the inequalities calculation:
   age_under16y <- c(30130, 30129) # all children included in "child with a parent with..." indicators
   age_4to12y <- c(99117, 30170, 30172, 30173, 30174, 30175) # all SDQ indicators pertain to 4-12 y olds
-  age_5to15y <- c(14003, 14006, 14007) # these child PA indicators restricted to 5-15y olds
+  age_5to15y <- c(14003, 14006, 14007, 14012) # these child PA indicators restricted to 5-15y olds
   age_2to15y <- c(30111) # child PA >1hr pertains to 2-15y olds
   
   agegp_pop <- ifelse(ind %in% age_under16y, "depr_pop_under16",
@@ -548,7 +513,7 @@ prepare_final_files <- function(ind){
   # calculate the inequality measures
   simd_data <- simd_data |>
     calculate_inequality_measures() |> # call helper function that will calculate sii/rii/paf
-    select(-c(indicator,overall_rate, total_pop, proportion_pop, most_rate,least_rate, par_rr, count)) #delete unwanted fields
+    select(-c(overall_rate, total_pop, proportion_pop, most_rate,least_rate, par_rr, count)) #delete unwanted fields
   
   # save the data as RDS file
   saveRDS(simd_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_ineq.rds"))
@@ -560,19 +525,18 @@ prepare_final_files <- function(ind){
   
 }
 
-
 # Run function to create final files
 prepare_final_files(ind = "self_assessed_health")
 prepare_final_files(ind = "limiting_long_term_condition")
-prepare_final_files(ind = "healthy_weight")
+prepare_final_files(ind = "adult_healthy_weight")
 prepare_final_files(ind = "food_insecurity")
 prepare_final_files(ind = "fruit_veg_consumption")
 prepare_final_files(ind = "common_mh_probs")
 prepare_final_files(ind = "mental_wellbeing") 
 prepare_final_files(ind = "physical_activity")
-prepare_final_files(ind = "binge_drinking")
-prepare_final_files(ind = "problem_drinker")
-prepare_final_files(ind = "weekly_alc_units")
+prepare_final_files(ind = "alc_binge_drinking")
+prepare_final_files(ind = "haz_or_harmful_drinker")
+prepare_final_files(ind = "alc_consumption_units")
 prepare_final_files(ind = "unpaid_caring") 
 prepare_final_files(ind = "life_satisfaction")  
 prepare_final_files(ind = "cyp_parent_w_ghq4")    
@@ -599,21 +563,22 @@ prepare_final_files(ind = "adults_very_low_activity")
 prepare_final_files(ind = "children_very_low_activity")
 prepare_final_files(ind = "children_participating_sport")
 prepare_final_files(ind = "children_active_play")
+prepare_final_files(ind = "children_meet_pa_recs_excl_school")
 
 
 # Run QA reports 
 # main data
 run_qa(type = "main", filename = "self_assessed_health", test_file = FALSE) 
-run_qa(type = "main", filename = "limiting_long_term_condition", test_file = FALSE) 
+run_qa(type = "main", filename = "limiting_long_term_condition", test_file = FALSE) # small diffs largely due to decimal places 
 run_qa(type = "main", filename = "food_insecurity", test_file = FALSE) 
 run_qa(type = "main", filename = "common_mh_probs", test_file = FALSE) 
 run_qa(type = "main", filename = "mental_wellbeing", test_file = FALSE) 
 run_qa(type = "main", filename = "physical_activity", test_file = FALSE) 
 run_qa(type = "main", filename = "fruit_veg_consumption", test_file = FALSE) 
-run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) 
-run_qa(type = "main", filename = "binge_drinking", test_file = FALSE)  
-run_qa(type = "main", filename = "problem_drinker", test_file = FALSE)  
-run_qa(type = "main", filename = "weekly_alc_units", test_file = FALSE)  
+run_qa(type = "main", filename = "adult_healthy_weight", test_file = FALSE) 
+run_qa(type = "main", filename = "alc_binge_drinking", test_file = FALSE)  
+run_qa(type = "main", filename = "haz_or_harmful_drinker", test_file = FALSE)  
+run_qa(type = "main", filename = "alc_consumption_units", test_file = FALSE)  
 run_qa(type = "main", filename = "unpaid_caring", test_file = FALSE)  
 run_qa(type = "main", filename = "life_satisfaction", test_file = FALSE)   
 run_qa(type = "main", filename = "involved_locally", test_file = FALSE)   
@@ -640,20 +605,21 @@ run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
 run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE)
 run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "main", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
 
 
 # ineq data: 
 run_qa(type = "deprivation", filename = "self_assessed_health", test_file=FALSE)
 run_qa(type = "deprivation", filename = "limiting_long_term_condition", test_file=FALSE)
-run_qa(type = "deprivation", filename = "healthy_weight", test_file=FALSE)
+run_qa(type = "deprivation", filename = "adult_healthy_weight", test_file=FALSE)
 run_qa(type = "deprivation", filename = "food_insecurity", test_file=FALSE)
 run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file=FALSE)
 run_qa(type = "deprivation", filename = "common_mh_probs", test_file=FALSE) # no 2023 or 2024: why?
 run_qa(type = "deprivation", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "deprivation", filename = "physical_activity", test_file=FALSE)
-run_qa(type = "deprivation", filename = "binge_drinking", test_file=FALSE)
-run_qa(type = "deprivation", filename = "problem_drinker", test_file=FALSE) # PAF data for this indicator a bit peculiar since gradient isn't simple (quintile 4 highest) - consider excluding just the PAF dat afor this indicator on next update? 
-run_qa(type = "deprivation", filename = "weekly_alc_units", test_file=FALSE)
+run_qa(type = "deprivation", filename = "alc_binge_drinking", test_file=FALSE)
+run_qa(type = "deprivation", filename = "haz_or_harmful_drinker", test_file=FALSE) # PAF data for this indicator a bit peculiar since gradient isn't simple (quintile 4 highest) - consider excluding just the PAF dat afor this indicator on next update? 
+run_qa(type = "deprivation", filename = "alc_consumption_units", test_file=FALSE)
 run_qa(type = "deprivation", filename = "unpaid_caring", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "life_satisfaction", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "involved_locally", test_file = FALSE)  
@@ -680,19 +646,20 @@ run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = 
 run_qa(type = "deprivation", filename = "children_very_low_activity", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "deprivation", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
 
 # popgrp data: 
 run_qa(type = "popgrp", filename = "self_assessed_health", test_file=FALSE)
 run_qa(type = "popgrp", filename = "limiting_long_term_condition", test_file=FALSE)
-run_qa(type = "popgrp", filename = "healthy_weight", test_file=FALSE)
+run_qa(type = "popgrp", filename = "adult_healthy_weight", test_file=FALSE)
 run_qa(type = "popgrp", filename = "food_insecurity", test_file=FALSE)
 run_qa(type = "popgrp", filename = "fruit_veg_consumption", test_file=FALSE)
 run_qa(type = "popgrp", filename = "common_mh_probs", test_file=FALSE)
 run_qa(type = "popgrp", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "popgrp", filename = "physical_activity", test_file=FALSE)
-run_qa(type = "popgrp", filename = "binge_drinking", test_file=FALSE)
-run_qa(type = "popgrp", filename = "problem_drinker", test_file=FALSE) 
-run_qa(type = "popgrp", filename = "weekly_alc_units", test_file=FALSE)
+run_qa(type = "popgrp", filename = "alc_binge_drinking", test_file=FALSE)
+run_qa(type = "popgrp", filename = "haz_or_harmful_drinker", test_file=FALSE) 
+run_qa(type = "popgrp", filename = "alc_consumption_units", test_file=FALSE)
 run_qa(type = "popgrp", filename = "unpaid_caring", test_file = FALSE) 
 run_qa(type = "popgrp", filename = "life_satisfaction", test_file = FALSE)  
 run_qa(type = "popgrp", filename = "involved_locally", test_file = FALSE)  
@@ -719,9 +686,12 @@ run_qa(type = "popgrp", filename = "adults_very_low_activity", test_file = FALSE
 run_qa(type = "popgrp", filename = "children_very_low_activity", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "popgrp", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
 
 
 #END
+
+
 
 
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -118,7 +118,8 @@ shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes
                               TRUE ~ "NA")) %>%
   # correct the equivalised income splits: (to be added to the survey data processing ultimately)
   # NB. quintiles have opposite ordering to SIMD (to match SHeS dashboard)
-  ## NEED TO CHANGE THIS IN THE PROCESSING FILE CODE
+  ## NEED TO CHANGE THIS IN THE PROCESSING FILE CODE: done June 2026, but not run. 
+  ## Remove this section next time the ukds_shes_processing.R script is run. 
   mutate(split_value = case_when(split_name == "Income (equivalised)" & split_value == "Q1 (lowest)" ~ "Q5 (lowest income)",
                                  split_name == "Income (equivalised)" & split_value == "Q5 (highest)" ~ "Q1 (highest income)",
                                  TRUE ~ split_value))
@@ -133,8 +134,20 @@ shes_from_ukds <- shes_from_ukds %>%
 # make a lookup for ind_id
 ind_ids <- shes_from_ukds %>%
   select(indicator, ind_id) %>%
-  unique()
+  unique() %>%
+  # rename these indicators to match the existing shiny files (were previously prepared in other scripts)
+  # NB need to change in the UKDS processing file to match, then remove this section.
+  mutate(indicator = case_when(indicator == "child_obesity_risk" ~ "child_healthyweight",
+                               indicator == "alc_consumption_units" ~ "weekly_alc_units", 
+                               indicator == "alc_binge_drinking" ~"binge_drinking" , 
+                               indicator == "haz_or_harmful_drinker" ~ "problem_drinker",
+                               indicator == "adult_healthy_weight" ~ "healthy_weight",
+                               TRUE ~ indicator))
 
+           
+
+                      
+                         
 
 ## SHeS dashboard data: 
 ## Can be downloaded from there but easier to get direct from the SHeS team (see open_data_to_2024 folder)
@@ -282,17 +295,17 @@ dashboard_vars_to_keep <- c("Alcohol consumption: Hazardous/Harmful drinker",
 shes_from_dashboard <- shes_from_dashboard %>%
   filter(ind %in% dashboard_vars_to_keep) %>%
   # add indicator names to match the UKDS data
-  mutate(indicator = case_when( ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "haz_or_harmful_drinker",
-                                ind == "Alcohol consumption (mean weekly units)" ~ "alc_consumption_units",
-                                ind == "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women" ~ "alc_binge_drinking",
+  mutate(indicator = case_when( ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
+                                ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units",
+                                ind == "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women" ~ "binge_drinking",
                                 ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",  
                                 ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",    
-                                ind == "Healthy weight: Healthy weight" ~ "adult_healthy_weight",
+                                ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
                                 ind == "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)" ~ "life_satisfaction",  
                                 ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",  
                                 ind == "Long-term conditions (children): Limiting long-term conditions" ~ "child_llti",
                                 ind == "Mental wellbeing" ~ "mental_wellbeing",    
-                                ind == "Multiple risks for poor health: Two or more" ~ "multi_health_risks", 
+                                ind == "Multiple risks for poor health: Two or more" ~ "health_risk_behaviours", 
                                 ind == "Participating in sport (children): Yes" ~ "children_participating_sport",
                                 ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",  
                                 ind == "Self-assessed general health (children): Very good/Good" ~ "child_general_health",
@@ -528,15 +541,11 @@ prepare_final_files <- function(ind){
 # Run function to create final files
 prepare_final_files(ind = "self_assessed_health")
 prepare_final_files(ind = "limiting_long_term_condition")
-prepare_final_files(ind = "adult_healthy_weight")
 prepare_final_files(ind = "food_insecurity")
 prepare_final_files(ind = "fruit_veg_consumption")
 prepare_final_files(ind = "common_mh_probs")
 prepare_final_files(ind = "mental_wellbeing") 
 prepare_final_files(ind = "physical_activity")
-prepare_final_files(ind = "alc_binge_drinking")
-prepare_final_files(ind = "haz_or_harmful_drinker")
-prepare_final_files(ind = "alc_consumption_units")
 prepare_final_files(ind = "unpaid_caring") 
 prepare_final_files(ind = "life_satisfaction")  
 prepare_final_files(ind = "cyp_parent_w_ghq4")    
@@ -564,21 +573,25 @@ prepare_final_files(ind = "children_very_low_activity")
 prepare_final_files(ind = "children_participating_sport")
 prepare_final_files(ind = "children_active_play")
 prepare_final_files(ind = "children_meet_pa_recs_excl_school")
+prepare_final_files(ind = "healthy_weight") 
+prepare_final_files(ind = "binge_drinking")
+prepare_final_files(ind = "problem_drinker")
+prepare_final_files(ind = "weekly_alc_units")
+prepare_final_files(ind = "health_risk_behaviours")
+prepare_final_files(ind = "child_healthyweight")
+prepare_final_files(ind = "child_general_health")
+prepare_final_files(ind = "child_llti")
 
 
 # Run QA reports 
 # main data
 run_qa(type = "main", filename = "self_assessed_health", test_file = FALSE) 
-run_qa(type = "main", filename = "limiting_long_term_condition", test_file = FALSE) # small diffs largely due to decimal places 
+run_qa(type = "main", filename = "limiting_long_term_condition", test_file = FALSE) # small diffs largely due to decimal places: ukds data includes more, so flagged as a % difference, particularly for smaller rates. CIs also oft different: our estimation might use different calculation  
 run_qa(type = "main", filename = "food_insecurity", test_file = FALSE) 
 run_qa(type = "main", filename = "common_mh_probs", test_file = FALSE) 
 run_qa(type = "main", filename = "mental_wellbeing", test_file = FALSE) 
 run_qa(type = "main", filename = "physical_activity", test_file = FALSE) 
 run_qa(type = "main", filename = "fruit_veg_consumption", test_file = FALSE) 
-run_qa(type = "main", filename = "adult_healthy_weight", test_file = FALSE) 
-run_qa(type = "main", filename = "alc_binge_drinking", test_file = FALSE)  
-run_qa(type = "main", filename = "haz_or_harmful_drinker", test_file = FALSE)  
-run_qa(type = "main", filename = "alc_consumption_units", test_file = FALSE)  
 run_qa(type = "main", filename = "unpaid_caring", test_file = FALSE)  
 run_qa(type = "main", filename = "life_satisfaction", test_file = FALSE)   
 run_qa(type = "main", filename = "involved_locally", test_file = FALSE)   
@@ -606,20 +619,24 @@ run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE
 run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "main", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
+run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) 
+run_qa(type = "main", filename = "binge_drinking", test_file = FALSE)  
+run_qa(type = "main", filename = "problem_drinker", test_file = FALSE)  
+run_qa(type = "main", filename = "weekly_alc_units", test_file = FALSE)  
+run_qa(type = "main", filename = "health_risk_behaviours", test_file = FALSE)
+run_qa(type = "main", filename = "child_healthyweight", test_file = FALSE)
+run_qa(type = "main", filename = "child_general_health", test_file = FALSE)
+run_qa(type = "main", filename = "child_llti", test_file = FALSE)
 
 
 # ineq data: 
 run_qa(type = "deprivation", filename = "self_assessed_health", test_file=FALSE)
 run_qa(type = "deprivation", filename = "limiting_long_term_condition", test_file=FALSE)
-run_qa(type = "deprivation", filename = "adult_healthy_weight", test_file=FALSE)
 run_qa(type = "deprivation", filename = "food_insecurity", test_file=FALSE)
 run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file=FALSE)
 run_qa(type = "deprivation", filename = "common_mh_probs", test_file=FALSE) # no 2023 or 2024: why?
 run_qa(type = "deprivation", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "deprivation", filename = "physical_activity", test_file=FALSE)
-run_qa(type = "deprivation", filename = "alc_binge_drinking", test_file=FALSE)
-run_qa(type = "deprivation", filename = "haz_or_harmful_drinker", test_file=FALSE) # PAF data for this indicator a bit peculiar since gradient isn't simple (quintile 4 highest) - consider excluding just the PAF dat afor this indicator on next update? 
-run_qa(type = "deprivation", filename = "alc_consumption_units", test_file=FALSE)
 run_qa(type = "deprivation", filename = "unpaid_caring", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "life_satisfaction", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "involved_locally", test_file = FALSE)  
@@ -647,19 +664,24 @@ run_qa(type = "deprivation", filename = "children_very_low_activity", test_file 
 run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
+run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "binge_drinking", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "problem_drinker", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "weekly_alc_units", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "health_risk_behaviours", test_file = FALSE)
+run_qa(type = "deprivation", filename = "child_healthyweight", test_file = FALSE)
+run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE)
+run_qa(type = "deprivation", filename = "child_llti", test_file = FALSE)
+
 
 # popgrp data: 
 run_qa(type = "popgrp", filename = "self_assessed_health", test_file=FALSE)
 run_qa(type = "popgrp", filename = "limiting_long_term_condition", test_file=FALSE)
-run_qa(type = "popgrp", filename = "adult_healthy_weight", test_file=FALSE)
 run_qa(type = "popgrp", filename = "food_insecurity", test_file=FALSE)
 run_qa(type = "popgrp", filename = "fruit_veg_consumption", test_file=FALSE)
 run_qa(type = "popgrp", filename = "common_mh_probs", test_file=FALSE)
 run_qa(type = "popgrp", filename = "mental_wellbeing", test_file=FALSE) 
 run_qa(type = "popgrp", filename = "physical_activity", test_file=FALSE)
-run_qa(type = "popgrp", filename = "alc_binge_drinking", test_file=FALSE)
-run_qa(type = "popgrp", filename = "haz_or_harmful_drinker", test_file=FALSE) 
-run_qa(type = "popgrp", filename = "alc_consumption_units", test_file=FALSE)
 run_qa(type = "popgrp", filename = "unpaid_caring", test_file = FALSE) 
 run_qa(type = "popgrp", filename = "life_satisfaction", test_file = FALSE)  
 run_qa(type = "popgrp", filename = "involved_locally", test_file = FALSE)  
@@ -687,7 +709,14 @@ run_qa(type = "popgrp", filename = "children_very_low_activity", test_file = FAL
 run_qa(type = "popgrp", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-
+run_qa(type = "popgrp", filename = "healthy_weight", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "binge_drinking", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "problem_drinker", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "weekly_alc_units", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "health_risk_behaviours", test_file = FALSE)
+run_qa(type = "popgrp", filename = "child_healthyweight", test_file = FALSE)
+run_qa(type = "popgrp", filename = "child_general_health", test_file = FALSE)
+run_qa(type = "popgrp", filename = "child_llti", test_file = FALSE)
 
 #END
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -1,133 +1,159 @@
-# TO DO:
-# look at other indicators that could be sourced from SHeS bulk data in this script.
 
 #########################################################
-# Scottish Health Survey data import
+# Scottish Health Survey indicator prep
 #########################################################
 
+# There are almost 50 ScotPHO indicators that are sourced from the Scottish Health Survey.
+# This script produces dashboard-ready files for all SHeS indicators EXCEPT FOR the 7 smoking prevalence indicators.
 
-### Update the 11 ScotPHO indicators that can be sourced from published Scottish Health Survey data: 
+#########################################################
+# STEP 1: 
+#########################################################
 
-### Care and Wellbeing indicators: 
-#   99105: Food insecurity
-#   99106: Adult Healthy Weight 
-#   99107: Summary activity levels (also MEN)*
-#   99108: Self-assessed health of adults (age 16+) (also MEN)*
-#   99109: Limiting long-term conditions (age 16+) (also MEN)*
-### Adult mental health indicators:
-#   30013: Fruit & vegetable consumption (guidelines) *
-#   30003: General health questionnaire (GHQ-12) *
-#   30001: Mental wellbeing (WEMWBS)*
-### Alcohol profile indicators:
-#   4170: Alcohol consumption: Binge drinking (drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" (previous indicator definition excluded non-drinkers from denom)
-#   4171: Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here) 
-#   4172: Alcohol consumption (mean weekly units)"
+# This script uses the data published on the SHeS dashboard https://scotland.shinyapps.io/sg-scottish-health-survey/ 
+# for the indicators that are published there (currently 21, as of May 2026, see below). 
+# (It can be easiest to request the published data direct from the SHeS team, scottishhealthsurvey@gov.scot) 
+# NB. Some indicators on their dashboard look similar but aren't defined/grouped in the way we need for ScotPHO indicators.
 
-### And adding data for a further 25 indicators (14 adult, 12 CYP) that have been processed in the ScotPHO_survey_data repo 
+#### 4170:  Alcohol consumption: Binge drinking (drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" (previous indicator definition excluded non-drinkers from denom)
+#### 4171:  Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here)
+#### 4172:  Alcohol consumption (mean weekly units)
+#### 14001: Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
+#### 14002: Adult very low PA: Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
+#### 30001: Mental wellbeing (WEMWBS): Mean score on the WEMWBS scale (adults). WEMWBS stands for Warwick-Edinburgh Mental Wellbeing Scale. N.B. This indicator is also available from the ScotPHO Online Profiles (national, health board, and council area level, but not by SIMD). The questionnaire consists of 14 positively worded items designed to assess: positive affect (optimism, cheerfulness, relaxation) and satisfying interpersonal relationships and positive functioning (energy, clear thinking, self-acceptance, personal development, mastery and autonomy). It is scored by summing the response to each item answered on a 1 to 5 Likert scale ('none of the time', 'rarely', 'some of the time', often', 'all of the time'). The total score ranges from 14 to 70 with higher scores indicating greater wellbeing. The variable used was WEMWBS.
+#### 30002: Life satisfaction: % scoring above the mode: Percentage with the highest levels of life satisfaction: responses above the mode (9 to 10-Extremely satisfied) when asked "All things considered, how satisfied are you with your life as a whole nowadays?"
+#### 30003: General health questionnaire (GHQ-12)Percentage of adults with a possible common mental health problem. N.B. This indicator is also available from the ScotPHO Online Profiles (national, health board, and council area level, but not by SIMD). A score of four or more on the General Health Questionnaire-12 (GHQ-12) indicates a possible mental health problem over the past few weeks. GHQ-12 is a standardised scale which measures mental distress and mental ill-health. There are 12 questions which cover concentration abilities, sleeping patterns, self-esteem, stress, despair, depression, and confidence in the past few weeks. For each of the 12 questions one point is given if the participant responded 'more than usual' or 'much more than usual'. Scores are then totalled to create an overall score of zero to twelve. A score of four or more (described as a high GHQ-12 score) is indicative of a potential psychiatric disorder. Conversely a score of zero is indicative of psychological wellbeing. As GHQ-12 measures only recent changes to someone's typical functioning it cannot be used to detect chronic conditions. The variable used was GHQg2.
+#### 30013: Fruit & vegetable consumption (guidelines): Percentage of adults who met the daily fruit and vegetable consumption recommendation - five or more portions - in the previous day (survey variables porftvg3Intake and porftvg3). According to the guidelines, it is recommended for adults to consume at least five varied portions of fruit and vegetables per day. The module includes questions on consumption of the following food types in the 24 hours to midnight preceding the interview: vegetables (fresh, frozen or canned); salads; pulses; vegetables in composites (e.g. vegetable chilli); fruit (fresh, frozen or canned); dried fruit; fruit in composites (e.g. apple pie); fresh fruit juice. Fruit and vegetable consumption figures for 2021 have been calculated from online dietary recalls using INTAKE24. In 2021, less than half a portion of fruit and vegetables is defined as none. This is due to the inclusion of fruit and vegetables from composite dishes which has led to a decrease in the proportion consuming no fruit or vegetables. Data from earlier years were taken from the fruit and vegetable module. Fruit and vegetable consumption data for NHS health boards and council area areas for 2017-2021 combined are not available, as due to the different method of data collection, it was not possible to combine data for these years. Respondents to the INTAKE24 food diary were included if they had provided data for two days.
+#### 99105: Food insecurity
+#### 99106: Adult Healthy Weight
+#### 99107: Summary activity levels (ADULT) Percentage of adults who met the recommended moderate or vigorous physical activity guideline in the previous four weeks. In July 2011, the Chief Medical Officers of each of the four UK countries agreed and introduced revised guidelines on physical activity. Adults are recommended to accumulate 150 minutes of moderate activity or 75 minutes of vigorous activity per week, or an equivalent combination of both, in bouts of 10 minutes or more. The variable used was adt10gpTW. This bandings used for this variable include the new walking definition for those aged 65 years and over.
+#### 99108: Self-assessed health of adults (age 16+) Percentage of adults who, when asked "How good is your health in general?", selected "good" or "very good". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
+#### 99109: Limiting long-term conditions (age 16+) Percentage of adults who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
+#### 99121: Health risk behaviours
+#### 30111: Children's PA guidelines:  % children meeting 1 hour PA per day (INCL. SCHOOL)
+#### 14003: Children with very low PA levels
+#### 14006: Children participating in sport
+#### 30114: Children's general health. Percentage of children who, when asked "How good is your health in general?", selected "good" or "excellent". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
+#### 30115: Children with Limiting long-term conditions.	Percentage of children who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
+#### 99144: Children at risk of obesity (2-15y) (Monica's indicator)
+
+#########################################################
+# STEP 2:
+#########################################################
+
+# Additional indicators (20 as of May 2026, listed below) can only be sourced from the UK Data Service (UKDS) microdata. 
+# The UKDS data are imported and processed in a separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
+# In that repo we calculate estimates for all available splits for all available indicators 
+# (including those available on the SHeS dashboard, listed above, as there could be additional splits that aren't published, 
+# despite being above the SHeS suppression threshold of denominators <30) 
+
+##### ADULTS
+#### 30004 = depsymp	Percentage of adults who had a symptom score of two or more on the depression section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was depsymp (or dvg11 in 2008). 
+#### 30005 = anxsymp	Percentage of adults who had a symptom score of two or more on the anxiety section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was anxsymp (or dvj12 in 2008). 
+#### 30009 = suicide2	Percentage of adults who made an attempt to take their own life, by taking an overdose of tablets or in some other way, in the past year. The variable used was suicide2. 
+#### 30010 = dsh5sc	Percentage of adults who deliberately harmed themselves but not with the intention of killing themselves in the past year. The variable used was DSH5 from 2008 to 2011, or DSH5SC from 2013 onwards. 
+#### 30021 = involve	Percentage of adults who, when asked "How involved do you feel in the local community?", responded "a great deal" or "a fair amount". The four possible options ranged from "a great deal" to "not at all". The variables used were Involve and INVOLV19. 
+#### 30023 = p_crisis	Percentage of adults with a primary support group of three or more to rely on for comfort and support in a personal crisis. Respondents were asked "If you had a serious personal crisis, how many people, if any, do you feel you could turn to for comfort and support?", and the variables were PCrisis or PCRIS19. 
+#### 30026 = rg17a_new	Percentage of adults who provide 20 or more hours of care per week to a member of their household or to someone not living with them, excluding help provided in the course of employment. Participants were asked whether they look after, or give any regular help or support to, family members, friends, neighbours or others because of a long-term physical condition, mental ill-health or disability; or problems related to old age. Caring which is done as part of any paid employment is not asked about. From 2014 onwards, this question explicitly instructed respondents to exclude caring as part of paid employment. The variables used to construc this indicator were RG15aNew (Do you provide any regular help or care for any sick, disabled, or frail people?) and RG17aNew (How many hours do you spend each week providing help or unpaid care for him/her/them?). 
+#### 30051 = str_work2	Percentage of adults who find their job "very stressful" or "extremely stressful". Respondents were asked "In general, how do you find your job?" and were given options from "not at all stressful" to "extremely stressful". The variable was StrWork2. 
+#### 30052 = work_bal	Mean score for how satisfied adults are with their work-life balance (paid work). Respondents were asked "How satisfied are you with the balance between the time you spend on your paid work and the time you spend on other aspects of your life?" on a scale between 0 (extremely dissatisfied) and 10 (extremely satisfied). The intervening scale points were numbered but not labelled. The variable was WorkBal. 
+#### 30053 = contrl	Percentage of adults who often or always have a choice in deciding how they do their work, in their current main job. The five possible responses ranged from "always" to "never". The variable was Contrl. 
+#### 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
+##### CHILDREN
+#### 14007 - ch30plyg - Children engaging in active play
+#### 30129 = ch_audit  Percentage of children aged 15 years or under with a parent/carer who reports consuming alcohol at hazardous or harmful levels (AUDIT questionnaire score 8+)
+#### 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
+#### 30170	Peer relationship problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the peer relationship problems scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30172	Emotional symptoms - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 4-10) on the emotional symptoms scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30173	Conduct problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the conduct problems scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
+
+#########################################################
+# STEP 3: 
+#########################################################
+
+### And adding data for a further 25 indicators (13 adult, 12 CYP) that have been processed in the ScotPHO_survey_data repo 
 ### (raw data processing elsewhere because they use UK Data Service data)
-### (data for SIMD x sex are also added for the 6 published variables above that are in the adult MH profile (see *), as these can be derived from the UKDS data.)
+### (data for SIMD x sex are also added for the 7 published variables above that are in the adult MH profile (see *), as these can be derived from the UKDS data.)
 ### (Mar 2026: stat.gov.scot data not published for 2024 yet, so will just use the additional geog - CA - for the indicators we get from UKDS)
 
-# Adult:
-# 30002 = life_sat	Mean score on the question "All things considered, how satisfied are you with your life as a whole nowadays?" (variable LifeSat).  N.B. This indicator is also available from the ScotPHO Online Profiles (national and council area level, but not by SIMD). Life satisfaction is measured by asking participants to rate, on a scale of 0 to 10, how satisfied they are with their life in general. On the scale, 0 represented 'extremely dissatisfied' and 10 'extremely satisfied' (the intervening scale points were numbered but not labelled). 
-# 30052 = work_bal	Mean score for how satisfied adults are with their work-life balance (paid work). Respondents were asked "How satisfied are you with the balance between the time you spend on your paid work and the time you spend on other aspects of your life?" on a scale between 0 (extremely dissatisfied) and 10 (extremely satisfied). The intervening scale points were numbered but not labelled. The variable was WorkBal. 
-# 30004 = depsymp	Percentage of adults who had a symptom score of two or more on the depression section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was depsymp (or dvg11 in 2008). 
-# 30005 = anxsymp	Percentage of adults who had a symptom score of two or more on the anxiety section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was anxsymp (or dvj12 in 2008). 
-# 30009 = suicide2	Percentage of adults who made an attempt to take their own life, by taking an overdose of tablets or in some other way, in the past year. The variable used was suicide2. 
-# 30010 = dsh5sc	Percentage of adults who deliberately harmed themselves but not with the intention of killing themselves in the past year. The variable used was DSH5 from 2008 to 2011, or DSH5SC from 2013 onwards. 
-# 30021 = involve	Percentage of adults who, when asked "How involved do you feel in the local community?", responded "a great deal" or "a fair amount". The four possible options ranged from "a great deal" to "not at all". The variables used were Involve and INVOLV19. 
-# 30023 = p_crisis	Percentage of adults with a primary support group of three or more to rely on for comfort and support in a personal crisis. Respondents were asked "If you had a serious personal crisis, how many people, if any, do you feel you could turn to for comfort and support?", and the variables were PCrisis or PCRIS19. 
-# 30051 = str_work2	Percentage of adults who find their job "very stressful" or "extremely stressful". Respondents were asked "In general, how do you find your job?" and were given options from "not at all stressful" to "extremely stressful". The variable was StrWork2. 
-# 30053 = contrl	Percentage of adults who often or always have a choice in deciding how they do their work, in their current main job. The five possible responses ranged from "always" to "never". The variable was Contrl. 
-# 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
-# 30026 = rg17a_new	Percentage of adults who provide 20 or more hours of care per week to a member of their household or to someone not living with them, excluding help provided in the course of employment. Participants were asked whether they look after, or give any regular help or support to, family members, friends, neighbours or others because of a long-term physical condition, mental ill-health or disability; or problems related to old age. Caring which is done as part of any paid employment is not asked about. From 2014 onwards, this question explicitly instructed respondents to exclude caring as part of paid employment. The variables used to construc this indicator were RG15aNew (Do you provide any regular help or care for any sick, disabled, or frail people?) and RG17aNew (How many hours do you spend each week providing help or unpaid care for him/her/them?). 
-# 14002 - adt10gp_tw_LOW - Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
-# 14001 - mus_rec - Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
-
-# CYP:
-# 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
-# 30129 = ch_audit  Percentage of children aged 15 years or under with a parent/carer who reports consuming alcohol at hazardous or harmful levels (AUDIT questionnaire score 8+)
-# 30170	Peer relationship problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the peer relationship problems scale of the Strengths and Difficulties Questionnaire (SDQ)
-# 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
-# 30172	Emotional symptoms - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 4-10) on the emotional symptoms scale of the Strengths and Difficulties Questionnaire (SDQ)
-# 30173	Conduct problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the conduct problems scale of the Strengths and Difficulties Questionnaire (SDQ)
-# 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
-# 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
-# 30111 % children meeting 1 hour PA per day
-# 14003 - c00sum7s - Children with very low activity levels
-# 14006 - spt1ch - Children participating in sport
-# 14007 - ch30plyg - Children engaging in active play
-
-
-# The published data are downloaded from statistics.gov.scot:
-# https://statistics.gov.scot/data/search?search=scottish+health+survey
-# 6 separate csv files are downloaded (for each split type, + Scotland and local areas)
-
-# Availability: 
-# all indicators available as male/female/all splits (Scotland, HB, CA)
-# all indicators also available for age, SIMD, income and long-term conditions splits (Scotland only).
-# This script runs the deprivation analysis on the SIMD-level data.
 
 
 ### functions/packages -----
 
 source("functions/main_analysis.R") # for packages and QA
 source("functions/deprivation_analysis.R") # for packages and QA
-
-# Run this lines below to install the opendata scotland package
-# devtools::install_github("ScotGovAnalysis/opendatascot",upgrade = "never",build_vignettes = TRUE)
 library(arrow) # for parquet files
-library(opendatascot) # for getting data from stats.gov.scot
 
-### 0. Get new data ---- 
-# # # Download each of the datasets 
-# # # (N.B. only do this if reading in new data. Latest downloaded = 2023, published in Nov 2024)
-# # # (persist if gives HTTP errors such as 302...)
-# SHeS_SCOTLAND <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data")
-# SHeS_LA <- opendatascot::ods_get_csv("scottish-health-survey-local-area-level-data")
-# SHeS_SIMD <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-simd")
-# SHeS_AGE <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-age")
-# SHeS_INCOME <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-equivalised-income")
-# SHeS_CONDITIONS <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-long-term-conditions")
-# 
-# 
-# #Write the datasets to the Received Data folder in .parquet format
-# write_parquet(SHeS_SCOTLAND, paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SCOTLAND.parquet"))
-# write_parquet(SHeS_LA, paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LA.parquet"))
-# write_parquet(SHeS_SIMD, paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SIMD.parquet"))
-# write_parquet(SHeS_AGE, paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_AGE.parquet"))
-# write_parquet(SHeS_INCOME, paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_INCOME.parquet"))
-# write_parquet(SHeS_CONDITIONS, paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LONGTERM_CONDITIONS.parquet"))
-
-### 1. Read in the downloaded and saved data ----
-
-# Published data from statistics.gov.scot:
-SHeS_SCOTLAND <- read_parquet(paste0(profiles_data_folder,"/Received Data/Scottish Health Survey/SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
-SHeS_LA <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
-SHeS_SIMD <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
-SHeS_AGE <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_AGE.parquet")) %>% mutate(split_name = "Age")
-SHeS_INCOME <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
-SHeS_CONDITIONS <- read_parquet(paste0(profiles_data_folder, "/Received Data/Scottish Health Survey/SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
+## SHeS folder
+shes_folder <- file.path(profiles_data_folder, "Received Data", "Scottish Health Survey")
 
 # Pre-processed UKDS data (UK data service)
-# The data read in below is prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# Last updated Mar 2026 (SHeS data up to 2024)
-shes_from_ukds <- readRDS(paste0(profiles_data_folder, "/Prepared Data/shes_raw.rds")) %>%
+# The data read in below has been prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
+# Last updated May 2026 (SHeS data up to 2024)
+shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes_raw.rds")) %>%
   mutate(code = as.character(code))
+
+
+
+# ### Do this if you need to extract the data from statistics.gov.scot (as of May 2026: not updated as quickly as the SHeS dashboard is) ---- 
+# Run lines below to install the opendata scotland package
+# devtools::install_github("ScotGovAnalysis/opendatascot",upgrade = "never",build_vignettes = TRUE)
+# library(opendatascot) # for getting data from stats.gov.scot
+# # # # Download each of the datasets 
+# # # # (N.B. only do this if reading in new data. Latest downloaded = 2023, published in Nov 2024)
+# # # # (persist if gives HTTP errors such as 302...)
+# # SHeS_SCOTLAND <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data")
+# # SHeS_LA <- opendatascot::ods_get_csv("scottish-health-survey-local-area-level-data")
+# # SHeS_SIMD <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-simd")
+# # SHeS_AGE <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-age")
+# # SHeS_INCOME <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-equivalised-income")
+# # SHeS_CONDITIONS <- opendatascot::ods_get_csv("scottish-health-survey-scotland-level-data-by-long-term-conditions")
+# # 
+# # #Write the datasets to the Received Data folder in .parquet format
+# # write_parquet(SHeS_SCOTLAND, file.path(shes_folder, "SHeS_SCOTLAND.parquet"))
+# # write_parquet(SHeS_LA, file.path(shes_folder, "SHeS_LA.parquet"))
+# # write_parquet(SHeS_SIMD, file.path(shes_folder, "SHeS_SIMD.parquet"))
+# # write_parquet(SHeS_AGE, file.path(shes_folder, "SHeS_AGE.parquet"))
+# # write_parquet(SHeS_INCOME, file.path(shes_folder, "SHeS_INCOME.parquet"))
+# # write_parquet(SHeS_CONDITIONS, file.path(shes_folder, "SHeS_LONGTERM_CONDITIONS.parquet"))
+# 
+# ### 1. Read in the downloaded and saved data ----
+# 
+# # Published data from statistics.gov.scot:
+# SHeS_SCOTLAND <- read_parquet(file.path(shes_folder, "SHeS_SCOTLAND.parquet")) %>% mutate(split_name = "Sex")
+# SHeS_LA <- read_parquet(file.path(shes_folder, "SHeS_LA.parquet")) %>% mutate(split_name = "Sex")
+# SHeS_SIMD <- read_parquet(file.path(shes_folder, "SHeS_SIMD.parquet")) %>% mutate(split_name = "Deprivation (SIMD)")
+# SHeS_AGE <- read_parquet(file.path(shes_folder, "SHeS_AGE.parquet")) %>% mutate(split_name = "Age")
+# SHeS_INCOME <- read_parquet(file.path(shes_folder, "SHeS_INCOME.parquet")) %>% mutate(split_name = "Income (equivalised)")
+# SHeS_CONDITIONS <- read_parquet(file.path(shes_folder, "SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
+
+## The dashboard data are more likely to be up to date: 
+## Obtained direct from the SHeS team (see open_data_2026 folder)
+SHeS_SCOTLAND <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
+SHeS_LA <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_rank_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
+SHeS_SIMD <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_simd_opendata.xlsx")) %>% mutate(split_name = "Deprivation (SIMD)")
+SHeS_AGE <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_age_opendata.xlsx")) %>% mutate(split_name = "Age")
+SHeS_INCOME <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_ei_opendata.xlsx")) %>% mutate(split_name = "Income (equivalised)")
+SHeS_CONDITIONS <- readxl::read_xlsx(file.path(shes_folder, "open_data_2026", "shes_trend_ltc_opendata.xlsx")) %>% mutate(split_name = "Long-term illness")
+
+
 
 # Mar 2026: no 2024 data in the statistics.gov.scot data yet, so keep all from UKDS raw microdata (all years)
 ###------------------------------------------------------------------------------------------------
 ### PUBLISHED DATA PROCESSING:
 ### 2. Combine data and get column data and formats right----
-shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
+shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
   bind_rows() %>% # append them together
-  mutate(code = ifelse(FeatureCode=="S92000003", "S00000001", FeatureCode)) %>% # recode Scotland
+  mutate(code = ifelse(GeographyCode=="S92000003", "S00000001", GeographyCode)) %>% # recode Scotland
   mutate(stat = case_when(Measurement=="95% Lower Confidence Limit" ~ "lowci", # recode the measures
                           Measurement=="95% Upper Confidence Limit" ~ "upci",
                           Measurement %in% c("Mean", "Percent") ~ "rate")) %>%
   rename(trend_axis = DateCode) %>%
   # create a new split_value column: coalesce combines non-NA values into a single column
-  mutate(split_value = coalesce(Age, Sex, `Long-term illness`, `Equivalised Income`, `SIMD quintiles`)) %>% # this works because there is only ever one non-NA cell in these 5 columns
+  mutate(split_value = coalesce(Age, Sex, LongtermConditions, EquivalisedIncome, SIMDquintiles)) %>% # this works because there is only ever one non-NA cell in these 5 columns
   mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
   mutate(split_value = case_when(split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
                                  split_value=="5 - least deprived" ~ "5",
@@ -137,10 +163,10 @@ shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the enviro
                                  split_value=="4th quintile" ~ "4",
                                  split_value=="5th-Bottom quintile" ~ "5 - lowest income",
                                  TRUE ~ split_value)) %>%
-  filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
-  
-  # keep the required columns
-  select(code, ind = `Scottish Health Survey Indicator`, trend_axis, split_name, split_value, stat, value = Value) %>%
+  #filter(split_name!="Age") %>% # now will use coarser age groups (dichotomised at 65y) so that can present at HB level too
+
+# keep the required columns
+  select(code, ind = ScottishHealthSurveyIndicator, trend_axis, split_name, split_value, stat, value = Value) %>%
   
   # reshape to wide
   pivot_wider(names_from=stat, values_from = value) %>%
@@ -152,53 +178,151 @@ shes_df <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the enviro
   mutate(year_diff =
            as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
          - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
-  mutate(year = case_when(year_diff <= 1 ~ as.numeric(substr(trend_axis, 1, 4)), # year = first/only year in the label
-                          year_diff>1 ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
-  mutate(def_period = ifelse(year_diff <= 1,
+  filter(year_diff!=1) %>% #drop the two-year aggregates
+  mutate(year = case_when(year_diff == 0 ~ as.numeric(substr(trend_axis, 1, 4)), # only one year in the label
+                          year_diff %in% c(3:4) ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
+  mutate(def_period = ifelse(year_diff==0,
                              paste0("Survey year (", trend_axis, ")"),
                              paste0("Aggregated survey years (", trend_axis, ")"))) %>%
   mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
-         sex = "Total")
+         sex = case_when(split_name=="Sex" ~ split_value,
+                         TRUE ~ "Total"))
 
 
 ### 3. Which indicators should be kept? ----
 
 # print out list of all available indicators in the data:
-unique(shes_df$ind)
+unique(shes_from_dashboard$ind)
 # look through to check which ones we need to keep
 
-# # check LLTI data:
-# # there are 2 similarly-named indicators for LLTI.
-# # they have overlapping temporal coverage, so need to look at the splits, geographies, and year-ranges involved
-# llti <- shes_df %>%
-#   filter(ind %in% c("Long-term conditions: Limiting long-term conditions",
-#                     "Long-term illness: Limiting long-term illness")) %>%
-#   mutate(geog = substr(code, 1, 3)) %>%
-#   select(ind, split_name, geog, year_diff) %>%
-#   unique() %>%
-#   pivot_wider(names_from = split_name, values_from = year_diff)
-# # Conclusion: "Long-term conditions" is the one to keep, "Long-term illness" just available for annual Scotland data, for fewer years than the LT conditions data.
-
 # List all the indicators we want to keep:
-keep_all <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)
-          "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)
-          "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)
-          "Food insecurity (worried would run out of food): Yes",  # 99105
-          "Healthy weight: Healthy weight" #99106
-          )
+# keep_all <- c("Drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women",  # binge drinking: M/F/Total (ind_id 4166, 4167, 4168) (NB. original ScotPHO indicator excluded non-drinkers from denominator)
+#           "Alcohol consumption (mean weekly units)", # units: can't use to derive % exceed weekly guidelines: M/F/Total (ind_id 4163-5)
+#           "Alcohol consumption: Hazardous/Harmful drinker", # Problem drinker: M/F/Total (ind_id 4169, 12554, 12555) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here, as for binge drinkers)
+#           "Food insecurity (worried would run out of food): Yes",  # 99105
+#           "Healthy weight: Healthy weight" #99106
+#           )
+# 
+# keep_only_ca <- c("Summary activity levels: Meets recommendations",  #99107
+#                   "Self-assessed general health: Very good/Good",    # 99108
+#                   "Fruit & vegetable consumption: 5 portions or more",  #30013
+#                   "Mental wellbeing", # 30001 (mean score, as in the indicator definition)
+#                   "General health questionnaire (GHQ-12): Score 4+", # 30003
+#                   "Long-term conditions: Limiting long-term conditions") # 99109
 
-keep_only_ca <- c("Summary activity levels: Meets recommendations",  #99107
-                  "Self-assessed general health: Very good/Good",    # 99108
-                  "Fruit & vegetable consumption: 5 portions or more",  #30013
-                  "Mental wellbeing", # 30001 (mean score, as in the indicator definition)
-                  "General health questionnaire (GHQ-12): Score 4+", # 30003
-                  "Long-term conditions: Limiting long-term conditions") # 99109
+dashboard_vars_to_keep <- c("Alcohol consumption: Hazardous/Harmful drinker",                                                                               
+                            "Alcohol consumption (mean weekly units)",                                                                                      
+                            "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women",                             
+                            "Healthy weight: Healthy weight",                                                                                               
+                            "Fruit & vegetable consumption: 5 portions or more",                                                                            
+                            "Worried would run out of food: Yes",                                                                                           
+                            "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)",                                                              
+                            "Self-assessed general health: Very good/Good",                                                                                 
+                            "Self-assessed general health (children): Very good/Good",                                                                      
+                            "Long-term conditions: Limiting long-term conditions",                                                                          
+                            "Long-term conditions (children): Limiting long-term conditions",                                                               
+                            "General health questionnaire (GHQ-12): Score 4+",                                                                              
+                            "Participating in sport (children): Yes",                                                                                       
+                            "Summary activity levels: Meets recommendations", 
+                            "Summary activity levels: Very low activity",
+                            "Summary activity levels (including school) (children): Meets recommendations",                                                 
+                            "Summary activity levels (including school) (children): Low activity",                                                          
+                            "Whether meets muscle strengthening recommendations: Yes",                                                                      
+                            "Mental wellbeing")                                                                                                             
+
+dashboard_vars_to_keep <- c(,                                                                               
+                            ,                                                                                      
+                            ,                             
+                            ,                                                                                               
+                            ,                                                                            
+                            ,                                                                                           
+                            ,                                                              
+                            ,                                                                                 
+                            "Self-assessed general health (children): Very good/Good",                                                                      
+                            ,                                                                          
+                            "Long-term conditions (children): Limiting long-term conditions",                                                               
+                            ,                                                                              
+                            ,                                                                                       
+                            , 
+                            ,
+                            ,                                                 
+                            ,                                                          
+                            ,                                                                      
+                            )    
+# involve...
+
+
+
+shes_from_dashboard <- shes_from_dashboard %>%
+  mutate(indicator = case_when( ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",    
+                                ind == "Self-assessed general health: Very good/Good" ~ "self_assessed_health",  
+                                ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",  
+                                ind == "Summary activity levels: Meets recommendations" ~ "physical_activity",
+                                ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",  
+                                ind == "Mental wellbeing" ~ "mental_wellbeing",    
+                                ind == "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)" ~ "life_satisfaction",  
+                                ind == "Summary activity levels (including school) (children): Meets recommendations" ~ "cyp_pa_over_1h_per_day",
+                                ind == "Summary activity levels: Very low activity" ~ "adults_very_low_activity",    
+                                ind == "Whether meets muscle strengthening recommendations: Yes" ~ "meeting_muscle_strengthening_recommendations",
+                                ind == "Summary activity levels (including school) (children): Low activity" ~ "children_very_low_activity",
+                                ind == "Participating in sport (children): Yes" ~ "children_participating_sport",
+                                ind == "Healthy weight: Healthy weight" ~ "adult_healthy_weight",
+                                ind == "Worried would run out of food: Yes" ~ "food_insecurity",
+                                ind == "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women" ~ "alc_binge_drinking",
+                                ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "haz_or_harmful_drinker",
+                                ind == "Alcohol consumption (mean weekly units)" ~ "alc_consumption_units",
+                                TRUE ~ as.character(NA)  )) %>%
+  indicator == "gh_qg2" ~ "common_mh_probs",    
+indicator == "gen_helf" ~ "self_assessed_health",  
+indicator == "limitill2" ~ "limiting_long_term_condition",  
+indicator == "adt10gp_tw2" ~ "physical_activity",
+indicator == "porftvg3" ~ "fruit_veg_consumption",  
+indicator == "rg17a_new" ~ "unpaid_caring", 
+indicator == "wemwbs" ~ "mental_wellbeing",    
+indicator == "lifesat2" ~ "life_satisfaction",  
+indicator == "cghq214" ~ "cyp_parent_w_ghq4",    
+indicator == "ch_audit" ~ "cyp_parent_w_harmful_alc",
+indicator == "involve" ~ "involved_locally",  
+indicator == "p_crisis" ~ "support_network", 
+indicator == "str_work2" ~ "stress_at_work",
+indicator == "contrl" ~ "choice_at_work",   
+indicator == "support1" ~ "line_manager", 
+indicator == "depsymp" ~ "depression_symptoms",  
+indicator == "anxsymp" ~ "anxiety_symptoms",  
+indicator == "dsh5sc" ~ "deliberate_selfharm",   
+indicator == "suicide2" ~ "attempted_suicide",
+indicator == "work_bal" ~ "work-life_balance",
+indicator == "sdq_totg" ~ "cyp_sdq_totaldiffs",
+indicator == "childpa1hr" ~ "cyp_pa_over_1h_per_day",
+indicator == "sdq_totg" ~ "cyp_sdq_totaldiffs",
+indicator == "sdq_peeg" ~ "cyp_sdq_peer",
+indicator == "sdq_cong" ~ "cyp_sdq_conduct",
+indicator == "sdq_hypg" ~ "cyp_sdq_hyperactivity",
+indicator == "sdq_emog" ~ "cyp_sdq_emotional",
+indicator == "sdq_pro" ~ "cyp_sdq_prosocial",
+indicator == "adt10gp_tw_LOW" ~ "adults_very_low_activity",    
+indicator == "mus_rec" ~ "meeting_muscle_strengthening_recommendations",
+indicator == "c00sum7s" ~ "children_very_low_activity",
+indicator == "spt1ch" ~ "children_participating_sport",
+indicator == "ch30plyg" ~ "children_active_play",
+indicator == "healthyweight" ~ "adult_healthy_weight",
+indicator == "foodinsecure" ~ "food_insecurity",
+indicator == "binge" ~ "alc_binge_drinking",
+indicator == "hazharmful" ~ "haz_or_harmful_drinker",
+indicator == "drating" ~ "alc_consumption_units",
+indicator == "cbmig5_new" ~ "child_obesity_risk",
+indicator == "child_gen_helf" ~ "child_general_health",
+indicator == "child_limitill2" ~ "child_llti",
 
 # keep the required indicators
 shes_keep_all <- shes_df %>%
   filter(ind %in% keep_all) 
 shes_keep_ca <- shes_df %>%
   filter(ind %in% keep_only_ca & substr(code, 1, 3) == "S12")
+
+shes_from_dashboard <- shes_from_dashboard %>%
+  filter(ind %in% dashboard_vars_to_keep) %>%
+  
 
 ### 4. Further processing:  ----
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -1,10 +1,15 @@
+# to do:
+# Get adult healthy weight var updated for lower geogs: looking to get the right bmivg5 variable from UKDS.
+# Don't update that indicatr until fixed. 
+
 
 #########################################################
 # Scottish Health Survey indicator prep
 #########################################################
 
 # There are almost 50 ScotPHO indicators that are sourced from the Scottish Health Survey.
-# This script produces dashboard-ready files for all SHeS indicators EXCEPT FOR the 7 smoking prevalence indicators.
+# This script produces dashboard-ready files for all SHeS indicators... 
+# EXCEPT FOR the 7 smoking prevalence indicators, and child healthy weight (extract received from SHeS including locality data).
 
 #########################################################
 # STEP 1: 
@@ -45,7 +50,7 @@
 # STEP 2:
 #########################################################
 
-# Additional indicators (21 as of May 2026, listed below) can only be sourced from the UK Data Service (UKDS) microdata. 
+# Additional indicators (20 as of May 2026, listed below) can only be sourced from the UK Data Service (UKDS) microdata. 
 # The UKDS data are imported and processed in a separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
 # In that repo we calculate estimates for all available splits for all available indicators, including those available on the SHeS dashboard (listed above), 
 # as there could be additional splits that aren't published, despite being above the SHeS suppression threshold of denominators <30). 
@@ -65,7 +70,7 @@
 #### 30052 = work_bal	Mean score for how satisfied adults are with their work-life balance (paid work). Respondents were asked "How satisfied are you with the balance between the time you spend on your paid work and the time you spend on other aspects of your life?" on a scale between 0 (extremely dissatisfied) and 10 (extremely satisfied). The intervening scale points were numbered but not labelled. The variable was WorkBal. 
 #### 30053 = contrl	Percentage of adults who often or always have a choice in deciding how they do their work, in their current main job. The five possible responses ranged from "always" to "never". The variable was Contrl. 
 #### 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
-##### CHILDREN (N=10)
+##### CHILDREN (N=9)
 #### 14007 - ch30plyg - Children engaging in active play
 #### 30129 = ch_audit  Percentage of children aged 15 years or under with a parent/carer who reports consuming alcohol at hazardous or harmful levels (AUDIT questionnaire score 8+)
 #### 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
@@ -75,7 +80,6 @@
 #### 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
 #### 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
 #### 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
-#### 99144: Children at risk of obesity (2-15y) (Monica's indicator: need to check how it compares with the data she's been provided with)
 
 #########################################################
 # STEP 3: 
@@ -103,7 +107,7 @@ shes_folder <- file.path(profiles_data_folder, "Received Data", "Scottish Health
 ### Read in the data -----
 #########################################################
 
-## Pre-processed UKDS data (UK data service)
+## Import the pre-processed UKDS data (UK data service)
 # The data read in below has been prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
 # Last updated June 2026 (SHeS data up to 2024)
 shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes_raw.rds")) %>%
@@ -116,40 +120,21 @@ shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes
                               substr(code, 1, 3)=="S32" ~ "PD",
                               substr(code, 1, 3)=="S37" ~ "HSCP",
                               TRUE ~ "NA")) %>%
-  # correct the equivalised income splits: (to be added to the survey data processing ultimately)
-  # NB. quintiles have opposite ordering to SIMD (to match SHeS dashboard)
-  ## NEED TO CHANGE THIS IN THE PROCESSING FILE CODE: done June 2026, but not run. 
-  ## Remove this section next time the ukds_shes_processing.R script is run. 
-  mutate(split_value = case_when(split_name == "Income (equivalised)" & split_value == "Q1 (lowest)" ~ "Q5 (lowest income)",
-                                 split_name == "Income (equivalised)" & split_value == "Q5 (highest)" ~ "Q1 (highest income)",
-                                 TRUE ~ split_value))
+  filter(!(split_name=="Deprivation (SIMD)" & areatype!="Scot" & sex!="Total")) # drop deprivation x sex for all lower geogs
 
-
-# which geogs do we want to keep/drop?
-# drop ADP and PD for PA profile indicators:
+# Drop any geogs we don't want
+# The PA profile indicators don't need ADP and PD geographies:
 pa_inds <- c(14001, 14002, 30111, 14003, 14006, 14007, 14012)
 shes_from_ukds <- shes_from_ukds %>%
   filter(!(ind_id %in% pa_inds & areatype %in% c("PD", "ADP")))
 
-# make a lookup for ind_id
+# Make a lookup for ind_id to indicator name, so can match with the dashboard data
 ind_ids <- shes_from_ukds %>%
   select(indicator, ind_id) %>%
-  unique() %>%
-  # rename these indicators to match the existing shiny files (were previously prepared in other scripts)
-  # NB need to change in the UKDS processing file to match, then remove this section.
-  mutate(indicator = case_when(indicator == "child_obesity_risk" ~ "child_healthyweight",
-                               indicator == "alc_consumption_units" ~ "weekly_alc_units", 
-                               indicator == "alc_binge_drinking" ~"binge_drinking" , 
-                               indicator == "haz_or_harmful_drinker" ~ "problem_drinker",
-                               indicator == "adult_healthy_weight" ~ "healthy_weight",
-                               TRUE ~ indicator))
+  unique() 
 
-           
 
-                      
-                         
-
-## SHeS dashboard data: 
+## Import SHeS dashboard data: 
 ## Can be downloaded from there but easier to get direct from the SHeS team (see open_data_to_2024 folder)
 SHeS_SCOTLAND <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
 SHeS_LA <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_rank_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
@@ -296,14 +281,14 @@ shes_from_dashboard <- shes_from_dashboard %>%
   filter(ind %in% dashboard_vars_to_keep) %>%
   # add indicator names to match the UKDS data
   mutate(indicator = case_when( ind == "Alcohol consumption: Hazardous/Harmful drinker" ~ "problem_drinker",
-                                ind == "Alcohol consumption (mean weekly units)" ~ "weekly_alc_units",
+                                ind == "Alcohol consumption (mean weekly units)" ~ "drinker_units",
                                 ind == "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women" ~ "binge_drinking",
                                 ind == "Fruit & vegetable consumption: 5 portions or more" ~ "fruit_veg_consumption",  
                                 ind == "General health questionnaire (GHQ-12): Score 4+" ~ "common_mh_probs",    
                                 ind == "Healthy weight: Healthy weight" ~ "healthy_weight",
                                 ind == "Life satisfaction: Above the mode (9 to 10-Extremely satisfied)" ~ "life_satisfaction",  
                                 ind == "Long-term conditions: Limiting long-term conditions" ~ "limiting_long_term_condition",  
-                                ind == "Long-term conditions (children): Limiting long-term conditions" ~ "child_llti",
+                                ind == "Long-term conditions (children): Limiting long-term conditions" ~ "cyp_llti",
                                 ind == "Mental wellbeing" ~ "mental_wellbeing",    
                                 ind == "Multiple risks for poor health: Two or more" ~ "health_risk_behaviours", 
                                 ind == "Participating in sport (children): Yes" ~ "children_participating_sport",
@@ -319,7 +304,7 @@ shes_from_dashboard <- shes_from_dashboard %>%
                                 TRUE ~ as.character(NA)  )) %>%
   # Add ind_id column using lookup created above
   merge(y=ind_ids, by="indicator", all.x=TRUE) %>%
-  mutate(ind_id = ifelse(indicator=="multi_health_risks", 99121, ind_id)) %>% #this indicator is not in UKDS data, so add its ind_id manually
+  mutate(ind_id = ifelse(indicator=="health_risk_behaviours", 99121, ind_id)) %>% #this indicator is not in UKDS data, so add its ind_id manually
   # Select relevant columns
   select(ind_id, indicator, code, areatype, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator) 
 
@@ -346,6 +331,7 @@ totals_to_add <- shes_from_dashboard %>%
   unique() %>%
   merge(y = splits_w_no_total, by=c("code", "indicator", "trend_axis", "areatype"), all.y=TRUE)
 
+# Add the totals to the original data
 shes_from_dashboard <- shes_from_dashboard %>%
   rbind(totals_to_add) %>%
   mutate(source="dashboard")
@@ -355,8 +341,8 @@ shes_from_dashboard <- shes_from_dashboard %>%
 #########################################################
 
 #indicators with different age groups to the dashboard data:
-# = adult low activity, adult meet muscle recs, child v low PA, child sport, child meets recs (incl school), child meets recs (excl school)
-pa_inds_agegp <- c(14001, 14002, 14006, 14003, 30111, 14012)
+# = adult low activity, adult meet muscle recs, child v low PA, child sport. 
+pa_inds_agegp <- c(14001, 14002, 14006, 14003)
 # remove the dashboard age group splits for these indicators
 
 source_comparison <- shes_from_dashboard %>%
@@ -386,16 +372,10 @@ ftable(source_comparison$indicator,
 ## UKDS provides SIMD splits by sex, dashboard doesn't.
 ## UKDS provides urban/rural splits, while dashboard doesn't
 
-# additionals for deprivation = splits by sex, + aggregate years and lower geogs
-# additionals for age group = aggregate years + lower geogs
-# additionals for equiv invome = aggregate years + lower geogs
-# additionals for sex = earlier aggregate data
 
-
-
-# keep UKDS where available
+# keep UKDS where available (for lower geogs)
 shes_combined <- shes_from_dashboard %>%
-  filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>%
+  filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>% #drop the dashboard data for indicators where we want to use different age groups
   filter(!split_name=="Long-term Illness") %>% # we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
   merge(y=shes_from_ukds, by=c("indicator", "ind_id", "split_name", "split_value", "sex", "code", "areatype", "trend_axis", "year", "def_period"), all=TRUE) %>%
   # .x is dashboard, .y is ukds, so we keep dashboard for Scotland, where available
@@ -405,11 +385,16 @@ shes_combined <- shes_from_dashboard %>%
          upci = ifelse(areatype=="Scot" & !is.na(rate.x), upci.x, upci.y),
          numerator = numerator.y, # there are no numerators in the dashboard extract
          source = ifelse(areatype=="Scot" & !is.na(rate.x), source.x, source.y)) %>%
+  mutate(rate = ifelse(ind_id==99121, rate.x, rate), # indicator 99121 (health risk behaviours) only available from dashboard, so keep dashboard data for all geogs where available
+         lowci = ifelse(ind_id==99121, lowci.x, lowci),
+         upci = ifelse(ind_id==99121, upci.x, upci),
+         source = ifelse(ind_id==99121, source.x, source)) %>%
   mutate(rate_diff = case_when(!is.na(rate.x) & !is.na(rate.y) ~ rate.x-rate.y, 
                                TRUE ~ as.numeric(NA)))
 #shes_from_dashboard has 25,693 records
-#shes_from_ukds has 612,347 records
-#shes_combined has 614,689 records
+#shes_from_ukds has 487,605 records
+#shes_combined has 489,947 records
+
 
 # how do the indicator values compare?
 shes_combined %>% 
@@ -418,7 +403,9 @@ shes_combined %>%
   geom_point(aes(x=rate.x, y=rate.y)) +
   facet_wrap(~indicator)
 # SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
-# SLIGHT DISCREPANCIES APPARENT THAT PROBABLY ARISE FROM THE UKDS DATA BEING A MORE SUPPRESSED VERSION OF THE RAW DATA THE SHES TEAM USE
+# THE LINES ARE MOSTLY PERFECTLY STRAIGHT 1:1 RELATIONSHIPS, BUT SOME SLIGHT DISCREPANCIES APPARENT: 
+# could be explained by UKDS estimates having more decimal places, and the UKDS data being slightly more suppressed than the raw data the SHeS team have access to
+
 
 ### 6. Check geographical availability: ----
 
@@ -434,7 +421,7 @@ availability <- shes_combined %>%
   summarise(count = n()) %>% # whether available for single/aggregated years only (count == 1), or both (count==2)
   ungroup()
 ftable(availability$indicator, availability$areatype, availability$split_name, availability$count)
-# shows some splits are available at two levels of temporal aggregation: single year and 4y
+# shows some splits are available at two levels of temporal aggregation: single year and 4y (i.e., have count==2)
 # main_data needs to select data at the level of aggregation of any lower geographies, if present, so that trend charts use the same trend_axis labels
 
 # make a list of the indicators this affects:
@@ -476,17 +463,27 @@ prepare_final_files <- function(ind){
              (areatype!="Scot" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
     select(ind_id, year, code, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
     mutate(split_value = factor(split_value, 
-                                levels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
-                                           "16 to 64y", "65y and over", 
-                                           "16-24", "25-34","35-44","45-54","55-64","65-74","75+",
-                                           "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
-                                           "No long-term illness", "Long-term illness"),
-                                labels = c("Total", "0 to 4y","2 to 4y", "4 to 11y", "4 to 8y", "5 to 11y", "9 to 12y", "12 to 15y",  
-                                           "16 to 64y", "65y and over", 
-                                           "16-24y", "25-34y","35-44y","45-54y","55-64y","65-74y","75y+",
-                                           "1", "1 - highest income","2","3","4", "5", "5 - lowest income","Female","Male",            
-                                           "No long-term illness", "Long-term illness"))) %>%
+                                levels = c("Total", 
+                                           "0 to 3y", "0 to 4y", "2 to 4y", "4 to 7y", "4 to 8y", "5 to 11y", "5 to 7y", "8 to 10y", "8 to 11y", "9 to 12y",
+                                           "11 to 12y", "12 to 15y", "13 to 15y", "16 to 64y", "65y and over", 
+                                           "16-24", "25-34", "35-44", "45-54", "55-64", "65-74", "75+",             
+                                           "1", "2", "3", "4", "5",   
+                                           "Q1 (highest income)", "Q2", "Q3", "Q4", "Q5 (lowest income)",
+                                           "Female", "Male",    
+                                           "No long-term illness", "Long-term illness",   
+                                           "Urban", "Rural"),
+                                labels = c("Total", 
+                                           "0 to 3y", "0 to 4y", "2 to 4y", "4 to 7y", "4 to 8y", "5 to 11y", "5 to 7y", "8 to 10y", "8 to 11y", "9 to 12y",
+                                           "11 to 12y", "12 to 15y", "13 to 15y", "16 to 64y", "65y and over", 
+                                           "16-24y", "25-34y", "35-44y", "45-54y", "55-64y", "65-74y", "75y+",             
+                                           "1", "2", "3", "4", "5",   
+                                           "Q1 (highest income)", "Q2", "Q3", "Q4", "Q5 (lowest income)",
+                                           "Female", "Male",    
+                                           "No long-term illness", "Long-term illness",   
+                                           "Urban", "Rural"))) %>%
     arrange(code, year, split_name, split_value)
+  
+  
   
   # Save
   write.csv(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
@@ -508,10 +505,10 @@ prepare_final_files <- function(ind){
   ind_id <- unique(simd_data$ind_id) # identify the indicator number 
   
   # get the right age groups for the inequalities calculation:
-  age_under16y <- c(30130, 30129) # all children included in "child with a parent with..." indicators
+  age_under16y <- c(30130, 30129, 30114, 30115, 99144) # all children included 
   age_4to12y <- c(99117, 30170, 30172, 30173, 30174, 30175) # all SDQ indicators pertain to 4-12 y olds
-  age_5to15y <- c(14003, 14006, 14007, 14012) # these child PA indicators restricted to 5-15y olds
-  age_2to15y <- c(30111) # child PA >1hr pertains to 2-15y olds
+  age_5to15y <- c(14003, 14006, 14007) # these child PA indicators restricted to 5-15y olds
+  age_2to15y <- c(30111, 14012) # child PA recs pertains to 2-15y olds
   
   agegp_pop <- ifelse(ind %in% age_under16y, "depr_pop_under16",
                       ifelse(ind %in% age_4to12y, "depr_pop_4to12",
@@ -573,27 +570,62 @@ prepare_final_files(ind = "children_very_low_activity")
 prepare_final_files(ind = "children_participating_sport")
 prepare_final_files(ind = "children_active_play")
 prepare_final_files(ind = "children_meet_pa_recs_excl_school")
-prepare_final_files(ind = "healthy_weight") 
 prepare_final_files(ind = "binge_drinking")
 prepare_final_files(ind = "problem_drinker")
-prepare_final_files(ind = "weekly_alc_units")
 prepare_final_files(ind = "health_risk_behaviours")
-prepare_final_files(ind = "child_healthyweight")
 prepare_final_files(ind = "child_general_health")
-prepare_final_files(ind = "child_llti")
+prepare_final_files(ind = "cyp_llti")
+prepare_final_files(ind = "drinker_units") 
+prepare_final_files(ind = "healthy_weight") 
 
 
 # Run QA reports 
-# main data
-run_qa(type = "main", filename = "self_assessed_health", test_file = FALSE) 
-run_qa(type = "main", filename = "limiting_long_term_condition", test_file = FALSE) # small diffs largely due to decimal places: ukds data includes more, so flagged as a % difference, particularly for smaller rates. CIs also oft different: our estimation might use different calculation  
-run_qa(type = "main", filename = "food_insecurity", test_file = FALSE) 
+
+# NB differences from previous file identified for many, as now we're using the UKDS data where available for lower geogs, rather than dashboard. 
+# Did this so that all coincident geographies have the same data (otherwise Ed council and HSCP highlighted as having slight differences, when they should be identical).
+# I looked at the differences and many concerned the confidence intervals rather than the rates (SHeS must use a different type of survey estimation calculation). 
+# Rates were very similar, though the UKDS figures had 2 decimal places compared with 0 for SHeS dashboard, which sometimes showed as a big % difference if the rate was small.
+# Rates sometimes differ between UKDS and dashboard by around 1 % point.
+# Will add explanatory note to the techdoc.
+
+###########################
+# Main data
+###########################
+
+# (a) main sample indicators (Scot + lower geogs)
 run_qa(type = "main", filename = "common_mh_probs", test_file = FALSE) 
-run_qa(type = "main", filename = "mental_wellbeing", test_file = FALSE) 
+run_qa(type = "main", filename = "self_assessed_health", test_file = FALSE) 
+run_qa(type = "main", filename = "life_satisfaction", test_file = FALSE)   # big diffs when run in 2026 due to change in definition
+run_qa(type = "main", filename = "limiting_long_term_condition", test_file = FALSE)  
 run_qa(type = "main", filename = "physical_activity", test_file = FALSE) 
 run_qa(type = "main", filename = "fruit_veg_consumption", test_file = FALSE) 
 run_qa(type = "main", filename = "unpaid_caring", test_file = FALSE)  
-run_qa(type = "main", filename = "life_satisfaction", test_file = FALSE)   
+run_qa(type = "main", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
+run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) # lower geogs only have data up to 2016-19 (same as existing ScotPHO data) NEEDS TO BE FIXED: WAITING FOR SHES COMMENT
+run_qa(type = "main", filename = "food_insecurity", test_file = FALSE) 
+run_qa(type = "main", filename = "binge_drinking", test_file = FALSE)  
+run_qa(type = "main", filename = "problem_drinker", test_file = FALSE)  
+run_qa(type = "main", filename = "mental_wellbeing", test_file = FALSE) 
+run_qa(type = "main", filename = "drinker_units", test_file = FALSE)  
+run_qa(type = "main", filename = "health_risk_behaviours", test_file = FALSE)
+run_qa(type = "main", filename = "cyp_parent_w_ghq4", test_file = FALSE)     
+run_qa(type = "main", filename = "cyp_parent_w_harmful_alc", test_file = FALSE) 
+run_qa(type = "main", filename = "cyp_pa_over_1h_per_day", test_file = FALSE) 
+run_qa(type = "main", filename = "cyp_sdq_totaldiffs", test_file = FALSE) 
+run_qa(type = "main", filename = "cyp_sdq_peer", test_file = FALSE)
+run_qa(type = "main", filename = "cyp_sdq_conduct", test_file = FALSE)
+run_qa(type = "main", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
+run_qa(type = "main", filename = "cyp_sdq_emotional", test_file = FALSE)
+run_qa(type = "main", filename = "cyp_sdq_prosocial", test_file = FALSE)
+run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE)
+run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
+run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
+run_qa(type = "main", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
+run_qa(type = "main", filename = "child_general_health", test_file = FALSE) 
+run_qa(type = "main", filename = "cyp_llti", test_file = FALSE) # new source explains the differences (was HBSC previously)
+
+# (b) smaller sample indicators (Scotland only)
 run_qa(type = "main", filename = "involved_locally", test_file = FALSE)   
 run_qa(type = "main", filename = "support_network", test_file = FALSE)  
 run_qa(type = "main", filename = "stress_at_work", test_file = FALSE) 
@@ -604,119 +636,108 @@ run_qa(type = "main", filename = "anxiety_symptoms", test_file = FALSE)
 run_qa(type = "main", filename = "deliberate_selfharm", test_file = FALSE)    
 run_qa(type = "main", filename = "attempted_suicide", test_file = FALSE) 
 run_qa(type = "main", filename = "work-life_balance", test_file = FALSE) 
-run_qa(type = "main", filename = "cyp_parent_w_ghq4", test_file = FALSE)     
-run_qa(type = "main", filename = "cyp_parent_w_harmful_alc", test_file = FALSE) 
-run_qa(type = "main", filename = "cyp_pa_over_1h_per_day", test_file = FALSE)
-run_qa(type = "main", filename = "cyp_sdq_totaldiffs", test_file = FALSE) 
-run_qa(type = "main", filename = "cyp_sdq_peer", test_file = FALSE)
-run_qa(type = "main", filename = "cyp_sdq_conduct", test_file = FALSE)
-run_qa(type = "main", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
-run_qa(type = "main", filename = "cyp_sdq_emotional", test_file = FALSE)
-run_qa(type = "main", filename = "cyp_sdq_prosocial", test_file = FALSE)
-run_qa(type = "main", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
-run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
-run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE)
-run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
-run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
-run_qa(type = "main", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) 
-run_qa(type = "main", filename = "binge_drinking", test_file = FALSE)  
-run_qa(type = "main", filename = "problem_drinker", test_file = FALSE)  
-run_qa(type = "main", filename = "weekly_alc_units", test_file = FALSE)  
-run_qa(type = "main", filename = "health_risk_behaviours", test_file = FALSE)
-run_qa(type = "main", filename = "child_healthyweight", test_file = FALSE)
-run_qa(type = "main", filename = "child_general_health", test_file = FALSE)
-run_qa(type = "main", filename = "child_llti", test_file = FALSE)
 
 
-# ineq data: 
-run_qa(type = "deprivation", filename = "self_assessed_health", test_file=FALSE)
-run_qa(type = "deprivation", filename = "limiting_long_term_condition", test_file=FALSE)
-run_qa(type = "deprivation", filename = "food_insecurity", test_file=FALSE)
-run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file=FALSE)
-run_qa(type = "deprivation", filename = "common_mh_probs", test_file=FALSE) # no 2023 or 2024: why?
-run_qa(type = "deprivation", filename = "mental_wellbeing", test_file=FALSE) 
-run_qa(type = "deprivation", filename = "physical_activity", test_file=FALSE)
-run_qa(type = "deprivation", filename = "unpaid_caring", test_file = FALSE) 
-run_qa(type = "deprivation", filename = "life_satisfaction", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "involved_locally", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "support_network", test_file = FALSE) 
-run_qa(type = "deprivation", filename = "stress_at_work", test_file = FALSE)
-run_qa(type = "deprivation", filename = "choice_at_work", test_file = FALSE)   
-run_qa(type = "deprivation", filename = "line_manager", test_file = FALSE) 
-run_qa(type = "deprivation", filename = "depression_symptoms", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "anxiety_symptoms", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "deliberate_selfharm", test_file = FALSE)   
-run_qa(type = "deprivation", filename = "attempted_suicide", test_file = FALSE)
-run_qa(type = "deprivation", filename = "work-life_balance", test_file = FALSE)
-run_qa(type = "deprivation", filename = "cyp_parent_w_ghq4", test_file = FALSE)    
-run_qa(type = "deprivation", filename = "cyp_parent_w_harmful_alc", test_file = FALSE)
-run_qa(type = "deprivation", filename = "cyp_pa_over_1h_per_day", test_file = FALSE)
-run_qa(type = "deprivation", filename = "cyp_sdq_totaldiffs", test_file = FALSE)
+
+###########################
+# Inequalities tab data: 
+###########################
+# some gaps at lower geogs 
+
+# (a) main sample indicators (Scot + lower geogs) (lower geogs will only have sex==Total)
+run_qa(type = "deprivation", filename = "common_mh_probs", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "self_assessed_health", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "life_satisfaction", test_file = FALSE)   
+run_qa(type = "deprivation", filename = "limiting_long_term_condition", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "physical_activity", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "unpaid_caring", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
+run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) # lower geogs only have data up to 2016-19 (same as existing ScotPHO data) NEEDS TO BE FIXED: WAITING FOR SHES COMMENT
+run_qa(type = "deprivation", filename = "food_insecurity", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "binge_drinking", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "problem_drinker", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "mental_wellbeing", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "drinker_units", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "health_risk_behaviours", test_file = FALSE) # Scotland only because all data are from dashboard
+# (ai) main children indicators: Scot only
+run_qa(type = "deprivation", filename = "cyp_parent_w_ghq4", test_file = FALSE)     
+run_qa(type = "deprivation", filename = "cyp_parent_w_harmful_alc", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "cyp_pa_over_1h_per_day", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "cyp_sdq_totaldiffs", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "cyp_sdq_peer", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_conduct", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "deprivation", filename = "cyp_sdq_prosocial", test_file = FALSE)
-run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
-run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_very_low_activity", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) 
-run_qa(type = "deprivation", filename = "binge_drinking", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "problem_drinker", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "weekly_alc_units", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "health_risk_behaviours", test_file = FALSE)
-run_qa(type = "deprivation", filename = "child_healthyweight", test_file = FALSE)
-run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE)
-run_qa(type = "deprivation", filename = "child_llti", test_file = FALSE)
+run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE) # Scot + Police Depts (WHY?)
+run_qa(type = "deprivation", filename = "cyp_llti", test_file = FALSE) # Scot + Police Depts (WHY?)
 
+# (b) smaller sample indicators (Scotland only)
+run_qa(type = "deprivation", filename = "involved_locally", test_file = FALSE)   
+run_qa(type = "deprivation", filename = "support_network", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "stress_at_work", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "choice_at_work", test_file = FALSE)    
+run_qa(type = "deprivation", filename = "line_manager", test_file = FALSE)  
+run_qa(type = "deprivation", filename = "depression_symptoms", test_file = FALSE)   
+run_qa(type = "deprivation", filename = "anxiety_symptoms", test_file = FALSE)   
+run_qa(type = "deprivation", filename = "deliberate_selfharm", test_file = FALSE)    
+run_qa(type = "deprivation", filename = "attempted_suicide", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "work-life_balance", test_file = FALSE) 
 
-# popgrp data: 
-run_qa(type = "popgrp", filename = "self_assessed_health", test_file=FALSE)
-run_qa(type = "popgrp", filename = "limiting_long_term_condition", test_file=FALSE)
-run_qa(type = "popgrp", filename = "food_insecurity", test_file=FALSE)
-run_qa(type = "popgrp", filename = "fruit_veg_consumption", test_file=FALSE)
-run_qa(type = "popgrp", filename = "common_mh_probs", test_file=FALSE)
-run_qa(type = "popgrp", filename = "mental_wellbeing", test_file=FALSE) 
-run_qa(type = "popgrp", filename = "physical_activity", test_file=FALSE)
-run_qa(type = "popgrp", filename = "unpaid_caring", test_file = FALSE) 
-run_qa(type = "popgrp", filename = "life_satisfaction", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "involved_locally", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "support_network", test_file = FALSE) 
-run_qa(type = "popgrp", filename = "stress_at_work", test_file = FALSE)
-run_qa(type = "popgrp", filename = "choice_at_work", test_file = FALSE)   
-run_qa(type = "popgrp", filename = "line_manager", test_file = FALSE) 
-run_qa(type = "popgrp", filename = "depression_symptoms", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "anxiety_symptoms", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "deliberate_selfharm", test_file = FALSE)   
-run_qa(type = "popgrp", filename = "attempted_suicide", test_file = FALSE)
-run_qa(type = "popgrp", filename = "work-life_balance", test_file = FALSE)
-run_qa(type = "popgrp", filename = "cyp_parent_w_ghq4", test_file = FALSE)    
-run_qa(type = "popgrp", filename = "cyp_parent_w_harmful_alc", test_file = FALSE)
-run_qa(type = "popgrp", filename = "cyp_pa_over_1h_per_day", test_file = FALSE)
-run_qa(type = "popgrp", filename = "cyp_sdq_totaldiffs", test_file = FALSE)
+###########################
+# Pop group tab data: 
+###########################
+
+# (a) main sample indicators (Scot + lower geogs)
+run_qa(type = "popgrp", filename = "common_mh_probs", test_file = FALSE) # not enough at lower geogs  # no 2023 or 2024: why?
+run_qa(type = "popgrp", filename = "self_assessed_health", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "life_satisfaction", test_file = FALSE)   # big diffs when run in 2026 due to change in definition
+run_qa(type = "popgrp", filename = "limiting_long_term_condition", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "physical_activity", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "fruit_veg_consumption", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "unpaid_caring", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
+run_qa(type = "popgrp", filename = "adults_very_low_activity", test_file = FALSE)
+run_qa(type = "popgrp", filename = "healthy_weight", test_file = FALSE) # lower geogs only have data up to 2016-19 (same as existing ScotPHO data) NEEDS TO BE FIXED: WAITING FOR SHES COMMENT
+run_qa(type = "popgrp", filename = "food_insecurity", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "binge_drinking", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "problem_drinker", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "mental_wellbeing", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "drinker_units", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "health_risk_behaviours", test_file = FALSE)
+run_qa(type = "popgrp", filename = "cyp_parent_w_ghq4", test_file = FALSE)     
+run_qa(type = "popgrp", filename = "cyp_parent_w_harmful_alc", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "cyp_pa_over_1h_per_day", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "cyp_sdq_totaldiffs", test_file = FALSE) 
 run_qa(type = "popgrp", filename = "cyp_sdq_peer", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_conduct", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_hyperactivity", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_emotional", test_file = FALSE)
 run_qa(type = "popgrp", filename = "cyp_sdq_prosocial", test_file = FALSE)
-run_qa(type = "popgrp", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
-run_qa(type = "popgrp", filename = "adults_very_low_activity", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_very_low_activity", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-run_qa(type = "popgrp", filename = "healthy_weight", test_file = FALSE) 
-run_qa(type = "popgrp", filename = "binge_drinking", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "problem_drinker", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "weekly_alc_units", test_file = FALSE)  
-run_qa(type = "popgrp", filename = "health_risk_behaviours", test_file = FALSE)
-run_qa(type = "popgrp", filename = "child_healthyweight", test_file = FALSE)
-run_qa(type = "popgrp", filename = "child_general_health", test_file = FALSE)
-run_qa(type = "popgrp", filename = "child_llti", test_file = FALSE)
+run_qa(type = "popgrp", filename = "child_general_health", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "cyp_llti", test_file = FALSE) # new source explains the differences (was HBSC previously)
+
+# (b) smaller sample indicators (Scotland only)
+run_qa(type = "popgrp", filename = "involved_locally", test_file = FALSE)   
+run_qa(type = "popgrp", filename = "support_network", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "stress_at_work", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "choice_at_work", test_file = FALSE)    
+run_qa(type = "popgrp", filename = "line_manager", test_file = FALSE)  
+run_qa(type = "popgrp", filename = "depression_symptoms", test_file = FALSE)   
+run_qa(type = "popgrp", filename = "anxiety_symptoms", test_file = FALSE)   
+run_qa(type = "popgrp", filename = "deliberate_selfharm", test_file = FALSE)    
+run_qa(type = "popgrp", filename = "attempted_suicide", test_file = FALSE) 
+run_qa(type = "popgrp", filename = "work-life_balance", test_file = FALSE) 
 
 #END
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -1,8 +1,3 @@
-# to do:
-# Get adult healthy weight var updated for lower geogs: looking to get the right bmivg5 variable from UKDS.
-# Don't update that indicatr until fixed. 
-
-
 #########################################################
 # Scottish Health Survey indicator prep
 #########################################################
@@ -11,58 +6,22 @@
 # This script produces dashboard-ready files for all SHeS indicators... 
 # EXCEPT FOR the 7 smoking prevalence indicators, and child healthy weight (extract received from SHeS including locality data).
 
-#########################################################
-# STEP 1: 
-#########################################################
+# The indicators covered by this script:
 
-# This script uses the data published on the SHeS dashboard https://scotland.shinyapps.io/sg-scottish-health-survey/ 
-# for the indicators that are published there (currently 21, as of May 2026, see below). 
-# (It can be easiest to request the published data direct from the SHeS team, scottishhealthsurvey@gov.scot) 
-# NB. Some indicators on their dashboard look similar but aren't defined/grouped in the way we want/need for ScotPHO indicators.
-
-## ADULTS (N=15)
-#### 4170:  Alcohol consumption: Binge drinking (drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" (previous indicator definition excluded non-drinkers from denom)
-#### 4171:  Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here)
-#### 4172:  Alcohol consumption (mean weekly units)
-#### 14001: Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
-#### 14002: Adult very low PA: Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
-#### 30001: Mental wellbeing (WEMWBS): Mean score on the WEMWBS scale (adults). WEMWBS stands for Warwick-Edinburgh Mental Wellbeing Scale. N.B. This indicator is also available from the ScotPHO Online Profiles (national, health board, and council area level, but not by SIMD). The questionnaire consists of 14 positively worded items designed to assess: positive affect (optimism, cheerfulness, relaxation) and satisfying interpersonal relationships and positive functioning (energy, clear thinking, self-acceptance, personal development, mastery and autonomy). It is scored by summing the response to each item answered on a 1 to 5 Likert scale ('none of the time', 'rarely', 'some of the time', often', 'all of the time'). The total score ranges from 14 to 70 with higher scores indicating greater wellbeing. The variable used was WEMWBS.
-#### 30002: Life satisfaction: % scoring above the mode: Percentage with the highest levels of life satisfaction: responses above the mode (9 to 10-Extremely satisfied) when asked "All things considered, how satisfied are you with your life as a whole nowadays?"
-#### 30003: General health questionnaire (GHQ-12)Percentage of adults with a possible common mental health problem. N.B. This indicator is also available from the ScotPHO Online Profiles (national, health board, and council area level, but not by SIMD). A score of four or more on the General Health Questionnaire-12 (GHQ-12) indicates a possible mental health problem over the past few weeks. GHQ-12 is a standardised scale which measures mental distress and mental ill-health. There are 12 questions which cover concentration abilities, sleeping patterns, self-esteem, stress, despair, depression, and confidence in the past few weeks. For each of the 12 questions one point is given if the participant responded 'more than usual' or 'much more than usual'. Scores are then totalled to create an overall score of zero to twelve. A score of four or more (described as a high GHQ-12 score) is indicative of a potential psychiatric disorder. Conversely a score of zero is indicative of psychological wellbeing. As GHQ-12 measures only recent changes to someone's typical functioning it cannot be used to detect chronic conditions. The variable used was GHQg2.
-#### 30013: Fruit & vegetable consumption (guidelines): Percentage of adults who met the daily fruit and vegetable consumption recommendation - five or more portions - in the previous day (survey variables porftvg3Intake and porftvg3). According to the guidelines, it is recommended for adults to consume at least five varied portions of fruit and vegetables per day. The module includes questions on consumption of the following food types in the 24 hours to midnight preceding the interview: vegetables (fresh, frozen or canned); salads; pulses; vegetables in composites (e.g. vegetable chilli); fruit (fresh, frozen or canned); dried fruit; fruit in composites (e.g. apple pie); fresh fruit juice. Fruit and vegetable consumption figures for 2021 have been calculated from online dietary recalls using INTAKE24. In 2021, less than half a portion of fruit and vegetables is defined as none. This is due to the inclusion of fruit and vegetables from composite dishes which has led to a decrease in the proportion consuming no fruit or vegetables. Data from earlier years were taken from the fruit and vegetable module. Fruit and vegetable consumption data for NHS health boards and council area areas for 2017-2021 combined are not available, as due to the different method of data collection, it was not possible to combine data for these years. Respondents to the INTAKE24 food diary were included if they had provided data for two days.
-#### 99105: Food insecurity
-#### 99106: Adult Healthy Weight
-#### 99107: Summary activity levels (ADULT) Percentage of adults who met the recommended moderate or vigorous physical activity guideline in the previous four weeks. In July 2011, the Chief Medical Officers of each of the four UK countries agreed and introduced revised guidelines on physical activity. Adults are recommended to accumulate 150 minutes of moderate activity or 75 minutes of vigorous activity per week, or an equivalent combination of both, in bouts of 10 minutes or more. The variable used was adt10gpTW. This bandings used for this variable include the new walking definition for those aged 65 years and over.
-#### 99108: Self-assessed health of adults (age 16+) Percentage of adults who, when asked "How good is your health in general?", selected "good" or "very good". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
-#### 99109: Limiting long-term conditions (age 16+) Percentage of adults who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
-#### 99121: Health risk behaviours (NO DATA EXTRACTED FROM UKDS DATA AS UNCLEAR HOW TO CODE)
-
-## CHILDREN (N=6)
-#### 30111: Children's PA guidelines:  % children meeting 1 hour PA per day (INCL. SCHOOL)
-#### 14003: Children with very low PA levels
-#### 14006: Children participating in sport
-#### 30114: Children's general health. Percentage of children who, when asked "How good is your health in general?", selected "good" or "excellent". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
-#### 30115: Children with Limiting long-term conditions.	Percentage of children who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
-#### 14012 % children meeting activity guidelines (NOT inc school) (var ch00sum7)
-
-
-#########################################################
-# STEP 2:
-#########################################################
-
-# Additional indicators (20 as of May 2026, listed below) can only be sourced from the UK Data Service (UKDS) microdata. 
-# The UKDS data are imported and processed in a separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# In that repo we calculate estimates for all available splits for all available indicators, including those available on the SHeS dashboard (listed above), 
-# as there could be additional splits that aren't published, despite being above the SHeS suppression threshold of denominators <30). 
-# Suppression of splits below that threshold is done in the ScotPHO_survey_data ukds_shes_calcs.R script, 
-# and any splits where more than 25% of the estimates have to be suppressed are removed entirely 
-# (25% was an entirely arbitrary figure from Liz's head, which seemed reasonable at the time).
-
-##### ADULTS (N=11)
+##### ADULTS (N=26)
+#### 4170 = Alcohol consumption: Binge drinking (drinking over (6/8) units in a day (includes non-drinkers): Over 8 units for men, over 6 units for women" (previous indicator definition excluded non-drinkers from denom)
+#### 4171 = Alcohol consumption: Hazardous/Harmful drinker" (% consuming over 14 units per week) (NB. original ScotPHO indicator excluded non-drinkers from denominator... it's not clear whether they are included here)
+#### 4172 = Alcohol consumption (mean weekly units)
+#### 14001 = Adults meeting muscle strengthening guidelines. 2011 CMO guidelines recommend 2x 30 minute muscle strengthening sessions per week
+#### 14002 = Adult very low PA: Adults with very low activity levels. Also in CWB, AMH profiles. 2011 CMO guidelines recommend 150 mins/week MVPA.
+#### 30001 = Mental wellbeing (WEMWBS): Mean score on the WEMWBS scale (adults). WEMWBS stands for Warwick-Edinburgh Mental Wellbeing Scale. N.B. This indicator is also available from the ScotPHO Online Profiles (national, health board, and council area level, but not by SIMD). The questionnaire consists of 14 positively worded items designed to assess: positive affect (optimism, cheerfulness, relaxation) and satisfying interpersonal relationships and positive functioning (energy, clear thinking, self-acceptance, personal development, mastery and autonomy). It is scored by summing the response to each item answered on a 1 to 5 Likert scale ('none of the time', 'rarely', 'some of the time', often', 'all of the time'). The total score ranges from 14 to 70 with higher scores indicating greater wellbeing. The variable used was WEMWBS.
+#### 30002 = Life satisfaction: % scoring above the mode: Percentage with the highest levels of life satisfaction: responses above the mode (9 to 10-Extremely satisfied) when asked "All things considered, how satisfied are you with your life as a whole nowadays?"
+#### 30003 = General health questionnaire (GHQ-12)Percentage of adults with a possible common mental health problem. N.B. This indicator is also available from the ScotPHO Online Profiles (national, health board, and council area level, but not by SIMD). A score of four or more on the General Health Questionnaire-12 (GHQ-12) indicates a possible mental health problem over the past few weeks. GHQ-12 is a standardised scale which measures mental distress and mental ill-health. There are 12 questions which cover concentration abilities, sleeping patterns, self-esteem, stress, despair, depression, and confidence in the past few weeks. For each of the 12 questions one point is given if the participant responded 'more than usual' or 'much more than usual'. Scores are then totalled to create an overall score of zero to twelve. A score of four or more (described as a high GHQ-12 score) is indicative of a potential psychiatric disorder. Conversely a score of zero is indicative of psychological wellbeing. As GHQ-12 measures only recent changes to someone's typical functioning it cannot be used to detect chronic conditions. The variable used was GHQg2.
 #### 30004 = depsymp	Percentage of adults who had a symptom score of two or more on the depression section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was depsymp (or dvg11 in 2008). 
 #### 30005 = anxsymp	Percentage of adults who had a symptom score of two or more on the anxiety section of the Revised Clinical Interview Schedule (CIS-R). A score of two or more indicates symptoms of moderate to high severity experienced in the previous week. The variable used was anxsymp (or dvj12 in 2008). 
 #### 30009 = suicide2	Percentage of adults who made an attempt to take their own life, by taking an overdose of tablets or in some other way, in the past year. The variable used was suicide2. 
 #### 30010 = dsh5sc	Percentage of adults who deliberately harmed themselves but not with the intention of killing themselves in the past year. The variable used was DSH5 from 2008 to 2011, or DSH5SC from 2013 onwards. 
+#### 30013 = Fruit & vegetable consumption (guidelines): Percentage of adults who met the daily fruit and vegetable consumption recommendation - five or more portions - in the previous day (survey variables porftvg3Intake and porftvg3). According to the guidelines, it is recommended for adults to consume at least five varied portions of fruit and vegetables per day. The module includes questions on consumption of the following food types in the 24 hours to midnight preceding the interview: vegetables (fresh, frozen or canned); salads; pulses; vegetables in composites (e.g. vegetable chilli); fruit (fresh, frozen or canned); dried fruit; fruit in composites (e.g. apple pie); fresh fruit juice. Fruit and vegetable consumption figures for 2021 have been calculated from online dietary recalls using INTAKE24. In 2021, less than half a portion of fruit and vegetables is defined as none. This is due to the inclusion of fruit and vegetables from composite dishes which has led to a decrease in the proportion consuming no fruit or vegetables. Data from earlier years were taken from the fruit and vegetable module. Fruit and vegetable consumption data for NHS health boards and council area areas for 2017-2021 combined are not available, as due to the different method of data collection, it was not possible to combine data for these years. Respondents to the INTAKE24 food diary were included if they had provided data for two days.
 #### 30021 = involve	Percentage of adults who, when asked "How involved do you feel in the local community?", responded "a great deal" or "a fair amount". The four possible options ranged from "a great deal" to "not at all". The variables used were Involve and INVOLV19. 
 #### 30023 = p_crisis	Percentage of adults with a primary support group of three or more to rely on for comfort and support in a personal crisis. Respondents were asked "If you had a serious personal crisis, how many people, if any, do you feel you could turn to for comfort and support?", and the variables were PCrisis or PCRIS19. 
 #### 30026 = rg17a_new	Percentage of adults who provide 20 or more hours of care per week to a member of their household or to someone not living with them, excluding help provided in the course of employment. Participants were asked whether they look after, or give any regular help or support to, family members, friends, neighbours or others because of a long-term physical condition, mental ill-health or disability; or problems related to old age. Caring which is done as part of any paid employment is not asked about. From 2014 onwards, this question explicitly instructed respondents to exclude caring as part of paid employment. The variables used to construc this indicator were RG15aNew (Do you provide any regular help or care for any sick, disabled, or frail people?) and RG17aNew (How many hours do you spend each week providing help or unpaid care for him/her/them?). 
@@ -70,29 +29,69 @@
 #### 30052 = work_bal	Mean score for how satisfied adults are with their work-life balance (paid work). Respondents were asked "How satisfied are you with the balance between the time you spend on your paid work and the time you spend on other aspects of your life?" on a scale between 0 (extremely dissatisfied) and 10 (extremely satisfied). The intervening scale points were numbered but not labelled. The variable was WorkBal. 
 #### 30053 = contrl	Percentage of adults who often or always have a choice in deciding how they do their work, in their current main job. The five possible responses ranged from "always" to "never". The variable was Contrl. 
 #### 30054 = support1	Percentage of adults who "strongly agree" or "tend to agree" that their line manager encourages them at work. The five options ranged from "strongly agree" to "strongly disagree". The variables used were Support1 and Support1_19. 
-##### CHILDREN (N=9)
-#### 14007 - ch30plyg - Children engaging in active play
+#### 99105 = Food insecurity
+#### 99106 = Adult Healthy Weight
+#### 99107 = Summary activity levels (ADULT) Percentage of adults who met the recommended moderate or vigorous physical activity guideline in the previous four weeks. In July 2011, the Chief Medical Officers of each of the four UK countries agreed and introduced revised guidelines on physical activity. Adults are recommended to accumulate 150 minutes of moderate activity or 75 minutes of vigorous activity per week, or an equivalent combination of both, in bouts of 10 minutes or more. The variable used was adt10gpTW. This bandings used for this variable include the new walking definition for those aged 65 years and over.
+#### 99108 = Self-assessed health of adults (age 16+) Percentage of adults who, when asked "How good is your health in general?", selected "good" or "very good". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
+#### 99109 = Limiting long-term conditions (age 16+) Percentage of adults who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
+#### 99121 = Health risk behaviours (NO DATA EXTRACTED FROM UKDS DATA AS UNCLEAR HOW TO CODE)
+
+##### CHILDREN (N=15)
+#### 14003 = Children with very low PA levels
+#### 14006 = Children participating in sport
+#### 14007 = ch30plyg - Children engaging in active play
+#### 14012 = % children meeting activity guidelines (NOT inc school) (var ch00sum7)
+#### 30111 = Children's PA guidelines:  % children meeting 1 hour PA per day (INCL. SCHOOL)
+#### 30114 = Children's general health. Percentage of children who, when asked "How good is your health in general?", selected "good" or "excellent". The five possible options ranged from very good to very bad, and the variable was GenHelf2.
+#### 30115 = Children with Limiting long-term conditions.	Percentage of children who have a limiting long-term illness. Long-term conditions are defined as a physical or mental health condition or illness lasting, or expected to last, 12 months or more. A long-term condition is defined as limiting if the respondent reported that it limited their activities in any way. The variable used was limitill.
 #### 30129 = ch_audit  Percentage of children aged 15 years or under with a parent/carer who reports consuming alcohol at hazardous or harmful levels (AUDIT questionnaire score 8+)
 #### 30130 = ch_ghq  Percentage of children aged 15 years or under who have a parent/carer who scores 4 or more on the General Health Questionnaire-12 (GHQ-12)
-#### 30170	Peer relationship problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the peer relationship problems scale of the Strengths and Difficulties Questionnaire (SDQ)
-#### 30172	Emotional symptoms - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 4-10) on the emotional symptoms scale of the Strengths and Difficulties Questionnaire (SDQ)
-#### 30173	Conduct problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the conduct problems scale of the Strengths and Difficulties Questionnaire (SDQ)
-#### 30174	Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
-#### 30175	Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
-#### 99117	Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
-
-#########################################################
-# STEP 3: 
-#########################################################
-
-# Check availability of the indicators from these two sources.
-# Use the SHeS dashboard data wherever available.
-# Prep the final ScotPHO dashboard indicator files
+#### 30170 = Peer relationship problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the peer relationship problems scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30172 = Emotional symptoms - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 4-10) on the emotional symptoms scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30173 = Conduct problems - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 3-10) on the conduct problems scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30174 = Hyperactivity/inattention - Percentage of children with a 'slightly raised', 'high' or 'very high' score (a score of 6-10) on the hyperactivity/inattention scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 30175 = Prosocial behaviour - Percentage of children with a 'close to average' score (a score of 8-10) on the prosocial scale of the Strengths and Difficulties Questionnaire (SDQ)
+#### 99117 = Total difficulties - Percentage of children with a 'slightly raised', 'high' or 'very high' total difficulties score (a score of 14-40) on the Strengths and Difficulties Questionnaire (SDQ). A total difficulties score of 14 or over is also referred to as borderline (14-16) or abnormal (17-40).
 
 
 #########################################################
-### Functions/packages -----
+# STEP 1: Import the processed UK Data Service data
 #########################################################
+
+# The UKDS data are imported and processed in a separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
+# In that repo we calculate estimates for all available splits for all available indicators, including those available on the SHeS dashboard, 
+# as there could be additional splits that aren't published (despite being above the SHeS suppression threshold of denominators <30). 
+# Suppression of splits below that threshold is done in the ScotPHO_survey_data ukds_shes_calcs.R script, 
+# and any splits where more than 25% of the estimates have to be suppressed are removed entirely 
+# (25% was an entirely arbitrary figure from Liz's head, which seemed reasonable at the time).
+
+
+#########################################################
+# STEP 2: Import and process the SHeS dashboard data
+#########################################################
+
+# This script uses the data published on the SHeS dashboard https://scotland.shinyapps.io/sg-scottish-health-survey/ 
+# for the indicators that are published there (currently 21, as of May 2026, see below). 
+# (It can be easiest to request the published data direct from the SHeS team, scottishhealthsurvey@gov.scot) 
+
+
+##############################################################################
+# STEP 3: Compare the two sources, combine, prep indicator files, and run QA
+##############################################################################
+
+# Check availability of the indicators from these two sources: decide which to keep.
+
+# Decision: 
+## Keep the SHeS dashboard data for indicators just available for Scotland.
+## If lower geogs are available for an indicator the Scotland data needs to match the aggregation level (e.g., 2021-24) of the lower geography data.
+## This is so that both can be plotted concurrently on the trends and ranks tabs.
+## SHeS dashboard Scotland data for single years can still be used for SIMD and popgroup tabs, as these only ever present a single geography at once.
+
+# Prep and QA the final ScotPHO dashboard indicator files
+
+
+
+### Functions/packages/paths -----
 
 source("functions/main_analysis.R") # for packages and QA
 source("functions/deprivation_analysis.R") # for packages and QA
@@ -104,12 +103,17 @@ shes_folder <- file.path(profiles_data_folder, "Received Data", "Scottish Health
 
 
 #########################################################
-### Read in the data -----
+# STEP 1: Import the processed UK Data Service data
 #########################################################
 
-## Import the pre-processed UKDS data (UK data service)
-# The data read in below has been prepared in separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
-# Last updated June 2026 (SHeS data up to 2024)
+# The UKDS data are imported and processed in a separate git repo https://github.com/Public-Health-Scotland/ScotPHO_survey_data
+# In that repo we calculate estimates for all available splits for all available indicators, including those available on the SHeS dashboard, 
+# as there could be additional splits that aren't published (despite being above the SHeS suppression threshold of denominators <30). 
+# Suppression of splits below that threshold is done in the ScotPHO_survey_data ukds_shes_calcs.R script, 
+# and any splits where more than 25% of the estimates have to be suppressed are removed entirely (rather than having suppressed estimates shown as NA)
+# (25% was an entirely arbitrary figure from Liz's head, which seemed reasonable at the time).
+
+# LATEST: to 2024
 shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes_raw.rds")) %>%
   mutate(code = as.character(code)) %>%
   mutate(source = "UKDS") %>%
@@ -134,7 +138,11 @@ ind_ids <- shes_from_ukds %>%
   unique() 
 
 
-## Import SHeS dashboard data: 
+#########################################################
+# STEP 2: Import and process the SHeS dashboard data
+#########################################################
+
+# LATEST: to 2024
 ## Can be downloaded from there but easier to get direct from the SHeS team (see open_data_to_2024 folder)
 SHeS_SCOTLAND <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_trend_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
 SHeS_LA <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024", "shes_rank_sex_opendata.xlsx")) %>% mutate(split_name = "Sex")
@@ -176,9 +184,7 @@ SHeS_CONDITIONS <- readxl::read_xlsx(file.path(shes_folder, "open_data_to_2024",
 # SHeS_CONDITIONS <- read_parquet(file.path(shes_folder, "SHeS_LONGTERM_CONDITIONS.parquet")) %>% mutate(split_name = "Long-term illness")
 
 
-#########################################################
 ### Process the published data -----
-#########################################################
 
 ### Combine data and get column data and formats right----
 shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes in the environment starting with "SHeS_"
@@ -188,22 +194,26 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
                           Measurement=="95% Upper Confidence Limit" ~ "upci",
                           Measurement %in% c("Mean", "Percent") ~ "rate")) %>%
   rename(trend_axis = DateCode) %>%
-  # create a new split_value column: coalesce combines non-NA values into a single column
-  mutate(split_value = coalesce(Age, Sex, LongtermConditions, EquivalisedIncome, SIMDquintiles)) %>% # this works because there is only ever one non-NA cell in these 5 columns
-  mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% # recode All -> Total
-  mutate(split_value = case_when(# Deprivation:
-    split_name == "Deprivation (SIMD)" & split_value=="1 - most deprived" ~ "1", # format needed for the inequalities analysis
+  # create a new split_value column: 
+  # coalesce() combines non-NA values into a single column: this works because there is only ever one non-NA cell in these 5 columns
+  mutate(split_value = coalesce(Age, Sex, LongtermConditions, EquivalisedIncome, SIMDquintiles)) %>%  
+  # recode All -> Total
+  mutate(split_value = if_else(split_value == "All", "Total", split_value)) %>% 
+  
+  mutate(split_value = case_when(
+    # recode deprivation splits (to format needed for inequalities analysis)
+    split_name == "Deprivation (SIMD)" & split_value=="1 - most deprived" ~ "1", 
     split_name == "Deprivation (SIMD)" & split_value=="2nd quintile" ~ "2",
     split_name == "Deprivation (SIMD)" & split_value=="3rd quintile" ~ "3",
     split_name == "Deprivation (SIMD)" & split_value=="4th quintile" ~ "4",
     split_name == "Deprivation (SIMD)" & split_value=="5 - least deprived" ~ "5",
-    # equivalised household income
-    split_name == "Income (equivalised)" & split_value=="1st-Top quintile" ~ "Q1 (highest income)", # match ScotPHO format
+    # recode equivalised household income (makes low and high explicit, and matches how quintiles are presented on ScotPHO)
+    split_name == "Income (equivalised)" & split_value=="1st-Top quintile" ~ "Q1 (highest income)", 
     split_name == "Income (equivalised)" & split_value=="2nd quintile" ~ "Q2", 
     split_name == "Income (equivalised)" & split_value=="3rd quintile" ~ "Q3", 
     split_name == "Income (equivalised)" & split_value=="4th quintile" ~ "Q4", 
     split_name == "Income (equivalised)" & split_value=="5th-Bottom quintile" ~ "Q5 (lowest income)",
-    # Age group:
+    # recode age groups (make units explicit):
     split_name == "Age group" & split_value=="0-3" ~ "0 to 3y",
     split_name == "Age group" & split_value=="11-12" ~ "11 to 12y",
     split_name == "Age group" & split_value=="12-15" ~ "12 to 15y",
@@ -213,7 +223,7 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
     split_name == "Age group" & split_value=="5-7" ~ "5 to 7y",
     split_name == "Age group" & split_value=="8-10" ~ "8 to 10y",
     split_name == "Age group" & split_value=="8-11" ~ "8 to 11y",
-    # long-term illness
+    # recode long-term illness (long-term illness seems to be the terminology now used)
     split_name == "Long-term Illness" & split_value=="Limiting long-term conditions" ~ "Limiting Long-term Illness",
     split_name == "Long-term Illness" & split_value=="No long-term conditions" ~ "No Long-term Illness",
     split_name == "Long-term Illness" & split_value=="Non-limiting long-term conditions" ~ "Non-limiting Long-term Illness",
@@ -232,14 +242,14 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
   mutate(year_diff =
            as.numeric(substr(trend_axis, nchar(trend_axis) - 3, nchar(trend_axis))) # the last year in trend_axis
          - as.numeric(substr(trend_axis, 1, 4))) %>% # minus the first year in trend_axis
-  filter(year_diff!=1) %>% #drop the two-year aggregates: we don't present these
+  filter(year_diff!=1) %>% #drop any two-year aggregates: we don't present these
   mutate(year = case_when(year_diff == 0 ~ as.numeric(substr(trend_axis, 1, 4)), # only one year in the label
                           year_diff %in% c(3:4) ~ as.numeric(substr(trend_axis, 1, 4))+2)) %>% # year = first year in the label + 2 (=mid point or midpoint rounded up to nearest whole year)
   mutate(def_period = ifelse(year_diff==0,
                              paste0("Survey year (", trend_axis, ")"),
                              paste0("Aggregated survey years (", trend_axis, ")"))) %>%
-  mutate(numerator = NA, # columns needed to get into same format as the imported UKDS data
-         sex = case_when(split_name=="Sex" ~ split_value,
+  mutate(numerator = NA, # columns needed for subsequent processing
+         sex = case_when(split_name=="Sex" ~ split_value, # make a separate sex column for all
                          TRUE ~ "Total")) %>%
   # identify the areatype
   mutate(areatype = case_when(substr(code, 1, 3)=="S00" ~ "Scot",
@@ -253,8 +263,10 @@ shes_from_dashboard <- mget(ls(pattern="^SHeS_")) %>% # get all the dataframes i
 # print out list of all available indicators in the data:
 unique(shes_from_dashboard$ind)
 # look through to check which ones we need to keep
+# NB. Some indicators on the SHeS dashboard look similar but aren't defined/grouped in the way we want/need for ScotPHO indicators.
 
-# List all the indicators we want to keep:
+
+# List all the indicators we want to keep (n=21):
 dashboard_vars_to_keep <- c("Alcohol consumption: Hazardous/Harmful drinker",                                                                               
                             "Alcohol consumption (mean weekly units)",                                                                                      
                             "Drinking over 6/8 units in a day (includes non-drinkers): Over 8 units for men/6 units for women",                             
@@ -308,8 +320,8 @@ shes_from_dashboard <- shes_from_dashboard %>%
   # Select relevant columns
   select(ind_id, indicator, code, areatype, year, trend_axis, def_period, sex, split_name, split_value, rate, lowci, upci, numerator) 
 
-# which indicator ids?
-inds_in_db <- shes_from_dashboard$ind_id %>% unique() #n=21
+# Do all the indicators now have ind_ids?
+inds_in_db <- shes_from_dashboard$ind_id %>% unique() #confirms that the 21 indicators now all have ind_id added
 
 ### Add totals for the popgroup and SIMD splits ----
 # This is needed for subsequent calculation of the inequalities metrics, and is nice-to-have for the popgroup data:
@@ -336,29 +348,48 @@ shes_from_dashboard <- shes_from_dashboard %>%
   rbind(totals_to_add) %>%
   mutate(source="dashboard")
 
-#########################################################
-### Compare availability -----
-#########################################################
+write_rds(shes_from_dashboard, "/conf/MHI_Data/derived data/shes_from_dashboard.rds")
+shes_from_dashboard <- readRDS("/conf/MHI_Data/derived data/shes_from_dashboard.rds")
 
-#indicators with different age groups to the dashboard data:
-# = adult low activity, adult meet muscle recs, child v low PA, child sport. 
+##############################################################################
+# STEP 3: Compare the two sources, combine, prep indicator files, and run QA
+##############################################################################
+
+### Compare SHeS dashboard and UKDS availability -----
+# Make a file containing the indicators available from both sources, and keep the comparable splits that are in both
+
+# Remove age groups for indicators where we want to use different age groups to the dashboard data:
+# = PA profile indicators = adult low activity, adult meet muscle recs, child v low PA, child sport. 
 pa_inds_agegp <- c(14001, 14002, 14006, 14003)
-# remove the dashboard age group splits for these indicators
 
 source_comparison <- shes_from_dashboard %>%
+  # drop age group splits as required
   filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>%
-  filter(!split_name=="Long-term Illness") %>% # we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
+  # drop LTI splits, as we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
+  filter(!split_name=="Long-term Illness") %>% 
   merge(y=shes_from_ukds, by=c("indicator", "ind_id", "code", "areatype", "year", "trend_axis", "def_period", "sex", "split_name", "split_value"), all=TRUE) %>%
-  filter(areatype %in% c("Scot", "HB", "CA") & ind_id %in% inds_in_db) %>% # UKDS provides any PD, HSCP or ADP splits, as these aren't available in the dashboard. 
-  mutate(final_source = ifelse(is.na(source.x), source.y, source.x))
+  # keep only the geogs available in the dashboard (this drops any PD, HSCP or ADP data in the UKDS data)
+  filter(areatype %in% c("Scot", "HB", "CA") & ind_id %in% inds_in_db) %>% 
+  mutate(on_dashboard = ifelse(is.na(source.x), "not on db", "on db"))
 
-# This comparison is limited to the indicators that are available from both sources (n=20 as of June 2026).
-# Another 21 (as of June 2026) are only available from the UKDS extract. One is only available from the dashboard data.
+# This comparison is limited to the indicators that are available from both sources:
 ftable(source_comparison$indicator, 
        source_comparison$split_name, 
-       source_comparison$final_source, 
+       source_comparison$on_dashboard, 
        source_comparison$areatype, 
        row.vars=c(1:2))
+
+# how do the indicator values compare?
+source_comparison %>% 
+  filter(!is.na(rate.x) & !is.na(rate.y)) %>%
+  ggplot() +
+  geom_point(aes(x=rate.x, y=rate.y)) +
+  facet_wrap(~indicator)
+# SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
+# THE LINES ARE MOSTLY PERFECTLY STRAIGHT 1:1 RELATIONSHIPS, BUT SOME SLIGHT DISCREPANCIES APPARENT: 
+# main reason: UKDS estimates have more decimal places
+# also some of our indicators for children's PA exclude some ages in the original data (children participating in sport, )
+
 
 # Key points about the two sources:
 ## Aggregated UKDS data start from 2008-11, while the aggregated dashboard data starts at 2012-15. 
@@ -372,40 +403,54 @@ ftable(source_comparison$indicator,
 ## UKDS provides SIMD splits by sex, dashboard doesn't.
 ## UKDS provides urban/rural splits, while dashboard doesn't
 
+# Decision: 
+## Keep the SHeS dashboard data for indicators just available for Scotland.
+## If lower geogs are available for an indicator the Scotland data needs to match the aggregation level (e.g., 2021-24) of the lower geography data.
+## This is so that both can be plotted concurrently on the trends and ranks tabs.
+## SHeS dashboard Scotland data for single years can still be used for SIMD and popgroup tabs, as these only ever present a single geography at once.
 
-# keep UKDS where available (for lower geogs)
+# Now we've compared the dashboard and UKDS data we can produce a file containing just the data we have decided to use. 
 shes_combined <- shes_from_dashboard %>%
-  filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>% #drop the dashboard data for indicators where we want to use different age groups
-  filter(!split_name=="Long-term Illness") %>% # we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
+  # drop the dashboard data for indicators where we want to use different age groups
+  filter(!(ind_id %in% pa_inds_agegp & split_name=="Age group")) %>% 
+  # drop the dashboard LTI splits, as we have opted to produce 2 llti splits (yes/no) rather than the 3 used on dashboard.
+  filter(!split_name=="Long-term Illness") %>% 
+  # merge in the UKDS data
   merge(y=shes_from_ukds, by=c("indicator", "ind_id", "split_name", "split_value", "sex", "code", "areatype", "trend_axis", "year", "def_period"), all=TRUE) %>%
-  # .x is dashboard, .y is ukds, so we keep dashboard for Scotland, where available
-  # opted to take lower geog data from UKDS processing, rather than dashboard data (even when available), so that all coincident geographies have the same data.
+  # .x is dashboard, .y is ukds
+  # Apply this logic:
+  # Scotland: keep dashboard data (.x) where available
+  # Lower geogs: keep UKDS data (.y), rather than dashboard data (even when available), so that all coincident geographies have precisely the same estimates and CIs (otherwise QA shows discrepancy).
   mutate(rate = ifelse(areatype=="Scot" & !is.na(rate.x), rate.x, rate.y), 
          lowci = ifelse(areatype=="Scot" & !is.na(rate.x), lowci.x, lowci.y),
          upci = ifelse(areatype=="Scot" & !is.na(rate.x), upci.x, upci.y),
          numerator = numerator.y, # there are no numerators in the dashboard extract
          source = ifelse(areatype=="Scot" & !is.na(rate.x), source.x, source.y)) %>%
-  mutate(rate = ifelse(ind_id==99121, rate.x, rate), # indicator 99121 (health risk behaviours) only available from dashboard, so keep dashboard data for all geogs where available
+  # indicator 99121 (health risk behaviours) only available from dashboard, so keep dashboard data for all geogs where available
+  mutate(rate = ifelse(ind_id==99121, rate.x, rate), 
          lowci = ifelse(ind_id==99121, lowci.x, lowci),
          upci = ifelse(ind_id==99121, upci.x, upci),
          source = ifelse(ind_id==99121, source.x, source)) %>%
   mutate(rate_diff = case_when(!is.na(rate.x) & !is.na(rate.y) ~ rate.x-rate.y, 
-                               TRUE ~ as.numeric(NA)))
+                               TRUE ~ as.numeric(NA)),
+         rate_diff = round(sqrt(rate_diff*rate_diff))) # magnitude of the difference, to 0 dp
 #shes_from_dashboard has 25,693 records
-#shes_from_ukds has 487,605 records
-#shes_combined has 489,947 records
+#shes_from_ukds has 499,383 records
+#shes_combined has 501,138 records
 
-
-# how do the indicator values compare?
-shes_combined %>% 
-  filter(!is.na(rate.x) & !is.na(rate.y)) %>%
-  ggplot() +
+# check big diffs
+check <- shes_combined %>%
+  filter(rate_diff>0)
+ggplot(check) +
   geom_point(aes(x=rate.x, y=rate.y)) +
   facet_wrap(~indicator)
-# SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
-# THE LINES ARE MOSTLY PERFECTLY STRAIGHT 1:1 RELATIONSHIPS, BUT SOME SLIGHT DISCREPANCIES APPARENT: 
-# could be explained by UKDS estimates having more decimal places, and the UKDS data being slightly more suppressed than the raw data the SHeS team have access to
+check_all <- shes_combined %>%
+  filter(!is.na(rate_diff))
 
+
+table(check_all$indicator)
+table(check$indicator)
+table(check$indicator, check$split_name)
 
 ### 6. Check geographical availability: ----
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -418,9 +418,9 @@ table(source_comparison$trend_axis[source_comparison$ind_id %in% c(30013, 4171)]
 ## UKDS provides urban/rural splits, while dashboard doesn't
 
 # Decision: 
-## Keep the SHeS dashboard data for indicators just available for Scotland.
-## If lower geogs are available for an indicator the Scotland data needs to match the aggregation level (e.g., 2021-24) of the lower geography data.
-## This is so that both can be plotted concurrently on the trends and ranks tabs.
+## Keep the SHeS dashboard data for Scotland single-year data, where available.
+## Lower geogs need to use aggregated years (e.g., 2021-24) so Scotland data also need to be available at this aggregation too 
+##  (so they can be plotted together on trends and ranks tabs): use our UKDS data in these cases.
 ## SHeS dashboard Scotland data for single years can still be used for SIMD and popgroup tabs, as these only ever present a single geography at once.
 
 # Now we've compared the dashboard and UKDS data we can produce a file containing just the data we have decided to use. 
@@ -433,8 +433,9 @@ shes_combined <- shes_from_dashboard %>%
   merge(y=shes_from_ukds, by=c("indicator", "ind_id", "split_name", "split_value", "sex", "code", "areatype", "trend_axis", "year", "def_period"), all=TRUE) %>%
   # .x is dashboard, .y is ukds
   # Apply this logic:
-  # Scotland: keep dashboard data (.x) where available
-  # Lower geogs: keep UKDS data (.y), rather than dashboard data (even when available), so that all coincident geographies have precisely the same estimates and CIs (otherwise QA shows discrepancy).
+  # Scotland: keep dashboard data (.x) where available (single year)
+  # Lower geogs and Scotland (aggregate years): keep UKDS data (.y), rather than dashboard data (even when available), 
+  # so that all coincident geographies have precisely the same estimates and CIs (otherwise QA shows discrepancy).
   mutate(rate = ifelse(areatype=="Scot" & !is.na(rate.x), rate.x, rate.y), 
          lowci = ifelse(areatype=="Scot" & !is.na(rate.x), lowci.x, lowci.y),
          upci = ifelse(areatype=="Scot" & !is.na(rate.x), upci.x, upci.y),

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -391,17 +391,18 @@ source_comparison %>%
   facet_wrap(~indicator)
 # SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
 # THE LINES ARE MOSTLY PERFECTLY STRAIGHT 1:1 RELATIONSHIPS, BUT SOME SLIGHT DISCREPANCIES APPARENT: 
-# some of our indicators for children's PA exclude some ages (2-4y) in the original data (children participating in sport, children very low activity) so the whole pop averages will be different
+# BIGGEST DISCREPANCIES = children participating in sport & children very low activity. These opt to exclude some ages (2-4y) that are present in the original data, so the whole pop averages will be different
 table(source_comparison$indicator, source_comparison$rate_diff)
-# of 19,454 rates we can compare: 
-# 450 (2%) are from the 2 child PA indicators with different age groups, 
-table(source_comparison$indicator[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
-# of remaining 19,004
-# 18507 (97%) are identical
-# 466 (2% are 1%pt either side)
-# biggest diffs are 4%pts lower and higher: fruitveg consumption and problem drinker
+# approx 2% of these comparisons are from the 2 child PA indicators with different age groups, 
 table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
-
+table(source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
+# of remaining 17,762
+# 17,299 (97%) are identical
+# 451 (3% are 1%pt either side)
+# biggest diffs are 4%pts lower and higher: fruitveg consumption (30013) and problem drinker (4171)
+table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
+table(source_comparison$trend_axis[source_comparison$ind_id %in% c(30013, 4171)], source_comparison$rate_diff[source_comparison$ind_id %in% c(30013, 4171)])
+# most concerned about problem drinkers in 2023: 1 at -2 and 7 at -1%pt. self-completion adjustment... try other weight instead?
 
 # Key points about the two sources:
 ## Aggregated UKDS data start from 2008-11, while the aggregated dashboard data starts at 2012-15. 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -124,7 +124,7 @@ shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes
                               substr(code, 1, 3)=="S32" ~ "PD",
                               substr(code, 1, 3)=="S37" ~ "HSCP",
                               TRUE ~ "NA")) %>%
-  mutate(rate = round(rate,0),
+  mutate(rate = round(rate,1), # SHeS round to 0dp, but 1dp gives better (less jagged) trends, and means rate always falls between CIs.
          lowci = round(lowci, 1),
          upci = round(upci, 1)) %>%
   filter(!(split_name=="Deprivation (SIMD)" & areatype!="Scot" & sex!="Total")) # drop deprivation x sex for all lower geogs
@@ -392,6 +392,7 @@ source_comparison %>%
 # SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
 # THE LINES ARE MOSTLY PERFECTLY STRAIGHT 1:1 RELATIONSHIPS, BUT SOME SLIGHT DISCREPANCIES APPARENT: 
 # BIGGEST DISCREPANCIES = children participating in sport & children very low activity. These opt to exclude some ages (2-4y) that are present in the original data, so the whole pop averages will be different
+# OTHER DISCREPANCIES = differences between 0dp rates (dashboard) and 1dp rates (ours from UKDS)
 table(source_comparison$indicator, source_comparison$rate_diff)
 # approx 2% of these comparisons are from the 2 child PA indicators with different age groups, 
 table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
@@ -445,8 +446,8 @@ shes_combined <- shes_from_dashboard %>%
          upci = ifelse(ind_id==99121, upci.x, upci),
          source = ifelse(ind_id==99121, source.x, source)) 
 #shes_from_dashboard has 25,693 records
-#shes_from_ukds has 499,662 records
-#shes_combined has 501,417 records
+#shes_from_ukds has 446,255 records
+#shes_combined has 448,010 records
 
 
 ### 6. Check geographical availability: ----
@@ -495,85 +496,90 @@ prepare_final_files <- function(ind){
   write.csv(main_data_final, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny.csv"), row.names = FALSE)
   write_rds(main_data_final, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny.rds"))
   
+  # Make data created available outside of function so it can be visually inspected if required
+  main_data_result <<- main_data_final
+  
   # 2 - population groups data (i.e. data behind population groups tab)
   # Contains single year Scotland data and lower geog aggregated data 
   # Can use single year and aggregated data in the popgrp tab (as will only ever be comparing across data with the same geog)
-  pop_grp_data <- shes_combined %>% 
-    filter(indicator == ind) %>% 
-    filter(split_name!="Deprivation (SIMD)") %>%
-    filter((areatype=="Scot" & str_detect(def_period, "Survey year ")) |  #select the un-aggregated data for Scotland
-             (areatype!="Scot" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
-    select(ind_id, year, code, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
-    mutate(split_value = factor(split_value, 
-                                levels = c("Total", 
-                                           "0 to 3y", "0 to 4y", "2 to 4y", "4 to 7y", "4 to 8y", "5 to 11y", "5 to 7y", "8 to 10y", "8 to 11y", "9 to 12y",
-                                           "11 to 12y", "12 to 15y", "13 to 15y", "16 to 64y", "65y and over", 
-                                           "16-24", "25-34", "35-44", "45-54", "55-64", "65-74", "75+",             
-                                           "1", "2", "3", "4", "5",   
-                                           "Q1 (highest income)", "Q2", "Q3", "Q4", "Q5 (lowest income)",
-                                           "Female", "Male",    
-                                           "No long-term illness", "Long-term illness",   
-                                           "Urban", "Rural"),
-                                labels = c("Total", 
-                                           "0 to 3y", "0 to 4y", "2 to 4y", "4 to 7y", "4 to 8y", "5 to 11y", "5 to 7y", "8 to 10y", "8 to 11y", "9 to 12y",
-                                           "11 to 12y", "12 to 15y", "13 to 15y", "16 to 64y", "65y and over", 
-                                           "16-24y", "25-34y", "35-44y", "45-54y", "55-64y", "65-74y", "75y+",             
-                                           "1", "2", "3", "4", "5",   
-                                           "Q1 (highest income)", "Q2", "Q3", "Q4", "Q5 (lowest income)",
-                                           "Female", "Male",    
-                                           "No long-term illness", "Long-term illness",   
-                                           "Urban", "Rural"))) %>%
-    arrange(code, year, split_name, split_value)
   
-  
-  
-  # Save
-  write.csv(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
-  write_rds(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.rds"))
-  
-  # Process SIMD data
-  simd_data <- shes_combined %>% 
-    filter(indicator == ind) %>% 
-    filter(split_name=="Deprivation (SIMD)") %>%
-    filter(!(areatype=="Scot" & str_detect(def_period, "Aggregated "))) %>% # for Scotland data, keep only the single year data
-    select(ind_id, year, code, sex, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
-    rename(quintile = split_value) %>%
-    mutate(quint_type="sc_quin") %>%
-    select(-split_name) %>%
-    arrange(code, year, quintile)
-  
-  # get arguments for the add_population_to_quintile_level_data() function: (done because the ind argument to the current function is not the same as the ind argument required by the next function)
-  ind_name <- ind # dataset will already be filtered to a single indicator based on the parameter supplied to 'prepare final files' function
-  ind_id <- unique(simd_data$ind_id) # identify the indicator number 
-  
-  # get the right age groups for the inequalities calculation:
-  age_under16y <- c(30130, 30129, 30114, 30115, 99144) # all children included 
-  age_4to12y <- c(99117, 30170, 30172, 30173, 30174, 30175) # all SDQ indicators pertain to 4-12 y olds
-  age_5to15y <- c(14003, 14006, 14007) # these child PA indicators restricted to 5-15y olds
-  age_2to15y <- c(30111, 14012) # child PA recs pertains to 2-15y olds
-  
-  agegp_pop <- ifelse(ind %in% age_under16y, "depr_pop_under16",
-                      ifelse(ind %in% age_4to12y, "depr_pop_4to12",
-                             ifelse(ind %in% age_2to15y, "depr_pop_2to15", 
-                                    ifelse(ind %in% age_5to15y, "depr_pop_5to15", "depr_pop_16+")))) # default is adult (16+)  
-  
-  # add population data (quintile level) so that inequalities can be calculated
-  simd_data <-  simd_data|>
-    add_population_to_quintile_level_data(pop="depr_pop_16+",ind = ind_id,ind_name = ind_name) |>
-    filter(!is.na(rate)) # some data biennial so not all years have data
-  
-  # calculate the inequality measures
-  simd_data <- simd_data |>
-    calculate_inequality_measures() |> # call helper function that will calculate sii/rii/paf
-    select(-c(overall_rate, total_pop, proportion_pop, most_rate,least_rate, par_rr, count)) #delete unwanted fields
-  
-  # save the data as RDS file
-  saveRDS(simd_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_ineq.rds"))
-  
-  # Make data created available outside of function so it can be visually inspected if required
-  main_data_result <<- main_data_final
-  pop_grp_data_result <<- pop_grp_data
-  simd_data_result <<- simd_data
+  if (ind != "attempted_suicide") { # counts too small for attempted suicide. keep it as Scotland only, no splits.
+    pop_grp_data <- shes_combined %>% 
+      filter(indicator == ind) %>% 
+      filter(split_name!="Deprivation (SIMD)") %>%
+      filter((areatype=="Scot" & str_detect(def_period, "Survey year ")) |  #select the un-aggregated data for Scotland
+               (areatype!="Scot" & str_detect(def_period, "Aggregated"))) %>%   # select the aggregated data for lower geogs
+      select(ind_id, year, code, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
+      mutate(split_value = factor(split_value, 
+                                  levels = c("Total", 
+                                             "0 to 3y", "0 to 4y", "2 to 4y", "4 to 7y", "4 to 8y", "5 to 11y", "5 to 7y", "8 to 10y", "8 to 11y", "9 to 12y",
+                                             "11 to 12y", "12 to 15y", "13 to 15y", "16 to 64y", "65y and over", 
+                                             "16-24", "25-34", "35-44", "45-54", "55-64", "65-74", "75+",             
+                                             "1", "2", "3", "4", "5",   
+                                             "Q1 (highest income)", "Q2", "Q3", "Q4", "Q5 (lowest income)",
+                                             "Female", "Male",    
+                                             "No long-term illness", "Long-term illness",   
+                                             "Urban", "Rural"),
+                                  labels = c("Total", 
+                                             "0 to 3y", "0 to 4y", "2 to 4y", "4 to 7y", "4 to 8y", "5 to 11y", "5 to 7y", "8 to 10y", "8 to 11y", "9 to 12y",
+                                             "11 to 12y", "12 to 15y", "13 to 15y", "16 to 64y", "65y and over", 
+                                             "16-24y", "25-34y", "35-44y", "45-54y", "55-64y", "65-74y", "75y+",             
+                                             "1", "2", "3", "4", "5",   
+                                             "Q1 (highest income)", "Q2", "Q3", "Q4", "Q5 (lowest income)",
+                                             "Female", "Male",    
+                                             "No long-term illness", "Long-term illness",   
+                                             "Urban", "Rural"))) %>%
+      arrange(code, year, split_name, split_value)
+    
+    
+    
+    # Save
+    write.csv(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.csv"), row.names = FALSE)
+    write_rds(pop_grp_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_shiny_popgrp.rds"))
+    
+    # Process SIMD data
+    simd_data <- shes_combined %>% 
+      filter(indicator == ind) %>% 
+      filter(split_name=="Deprivation (SIMD)") %>%
+      filter(!(areatype=="Scot" & str_detect(def_period, "Aggregated "))) %>% # for Scotland data, keep only the single year data
+      select(ind_id, year, code, sex, split_name, split_value, numerator, rate, upci, lowci, trend_axis, def_period) %>%
+      rename(quintile = split_value) %>%
+      mutate(quint_type="sc_quin") %>%
+      select(-split_name) %>%
+      arrange(code, year, quintile)
+    
+    # get arguments for the add_population_to_quintile_level_data() function: (done because the ind argument to the current function is not the same as the ind argument required by the next function)
+    ind_name <- ind # dataset will already be filtered to a single indicator based on the parameter supplied to 'prepare final files' function
+    ind_id <- unique(simd_data$ind_id) # identify the indicator number 
+    
+    # get the right age groups for the inequalities calculation:
+    age_under16y <- c(30130, 30129, 30114, 30115, 99144) # all children included 
+    age_4to12y <- c(99117, 30170, 30172, 30173, 30174, 30175) # all SDQ indicators pertain to 4-12 y olds
+    age_5to15y <- c(14003, 14006, 14007) # these child PA indicators restricted to 5-15y olds
+    age_2to15y <- c(30111, 14012) # child PA recs pertains to 2-15y olds
+    
+    agegp_pop <- ifelse(ind %in% age_under16y, "depr_pop_under16",
+                        ifelse(ind %in% age_4to12y, "depr_pop_4to12",
+                               ifelse(ind %in% age_2to15y, "depr_pop_2to15", 
+                                      ifelse(ind %in% age_5to15y, "depr_pop_5to15", "depr_pop_16+")))) # default is adult (16+)  
+    
+    # add population data (quintile level) so that inequalities can be calculated
+    simd_data <-  simd_data|>
+      add_population_to_quintile_level_data(pop="depr_pop_16+",ind = ind_id,ind_name = ind_name) |>
+      filter(!is.na(rate)) # some data biennial so not all years have data
+    
+    # calculate the inequality measures
+    simd_data <- simd_data |>
+      calculate_inequality_measures() |> # call helper function that will calculate sii/rii/paf
+      select(-c(overall_rate, total_pop, proportion_pop, most_rate,least_rate, par_rr, count)) #delete unwanted fields
+    
+    # save the data as RDS file
+    saveRDS(simd_data, paste0(profiles_data_folder, "/Data to be checked/", ind, "_ineq.rds"))
+    
+    # Make data created available outside of function so it can be visually inspected if required
+    pop_grp_data_result <<- pop_grp_data
+    simd_data_result <<- simd_data
+  }
   
 }
 
@@ -624,8 +630,8 @@ prepare_final_files(ind = "healthy_weight")
 # Run QA reports 
 
 # NB differences from previous file identified for many, as now we're using the UKDS data where available for lower geogs, rather than dashboard. 
-# Also because we're no rounding to 0dp to match SHeS dashboard, so this looks like a 'difference' in the QA process
-# Did this so that all coincident geographies have the same data (otherwise Ed council and HSCP highlighted as having slight differences, when they should be identical).
+# (Did this so that all coincident geographies have the same data (otherwise QA highlights Ed council and HSCP as having slight differences, when they should be identical)).
+# Also because we're not rounding to 0dp to match SHeS dashboard, so this looks like a 'difference' in the QA process
 # I looked at the differences and many concerned the confidence intervals rather than the rates (SHeS must use a different type of survey estimation calculation). 
 
 ###########################
@@ -686,7 +692,7 @@ run_qa(type = "main", filename = "work-life_balance", test_file = FALSE)
 
 # (a) main sample indicators (Scot + lower geogs) (lower geogs will only have sex==Total)
 # NB. latest = 2024 for Scotland, but 2021-24 (shown in QA shiny plot as year==2023) for lower geogs
-# some lower geogs are missing (geog tallies show red in QA) as values could only be produced for fewer than 3 quintiles (island boards kept if they have values for 3 or 4 quintiles)
+# some lower geogs are missing (geog tallies show red in QA) as values were only available/unsuppressed for <3 quintiles (island boards kept if they have values for 3 or 4 quintiles)
 run_qa(type = "deprivation", filename = "common_mh_probs", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "self_assessed_health", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "life_satisfaction", test_file = FALSE)   
@@ -718,8 +724,8 @@ run_qa(type = "deprivation", filename = "children_very_low_activity", test_file 
 run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE) 
-run_qa(type = "deprivation", filename = "cyp_llti", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE) # no previous file as was previously from HBSC
+run_qa(type = "deprivation", filename = "cyp_llti", test_file = FALSE) # no previous file as was previously from HBSC
 
 # (b) smaller sample indicators (Scotland only)
 run_qa(type = "deprivation", filename = "involved_locally", test_file = FALSE)   
@@ -730,7 +736,7 @@ run_qa(type = "deprivation", filename = "line_manager", test_file = FALSE)
 run_qa(type = "deprivation", filename = "depression_symptoms", test_file = FALSE)   
 run_qa(type = "deprivation", filename = "anxiety_symptoms", test_file = FALSE)   
 run_qa(type = "deprivation", filename = "deliberate_selfharm", test_file = FALSE)    
-run_qa(type = "deprivation", filename = "attempted_suicide", test_file = FALSE) #drop ineqs and other splits now
+#run_qa(type = "deprivation", filename = "attempted_suicide", test_file = FALSE) #small numbers: have now removed ineqs and other splits from data prep function
 run_qa(type = "deprivation", filename = "work-life_balance", test_file = FALSE) 
 
 ###########################
@@ -768,7 +774,7 @@ run_qa(type = "popgrp", filename = "children_participating_sport", test_file = F
 run_qa(type = "popgrp", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "popgrp", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
 run_qa(type = "popgrp", filename = "child_general_health", test_file = FALSE) 
-run_qa(type = "popgrp", filename = "cyp_llti", test_file = FALSE) # new source explains the differences (was HBSC previously)
+run_qa(type = "popgrp", filename = "cyp_llti", test_file = FALSE) 
 
 # (b) smaller sample indicators (Scotland only)
 run_qa(type = "popgrp", filename = "involved_locally", test_file = FALSE)   
@@ -779,8 +785,8 @@ run_qa(type = "popgrp", filename = "line_manager", test_file = FALSE)
 run_qa(type = "popgrp", filename = "depression_symptoms", test_file = FALSE)   
 run_qa(type = "popgrp", filename = "anxiety_symptoms", test_file = FALSE)   
 run_qa(type = "popgrp", filename = "deliberate_selfharm", test_file = FALSE)    
-run_qa(type = "popgrp", filename = "attempted_suicide", test_file = FALSE) 
-run_qa(type = "popgrp", filename = "work-life_balance", test_file = FALSE) 
+#run_qa(type = "popgrp", filename = "attempted_suicide", test_file = FALSE) #small numbers: have now removed ineqs and other splits from data prep function
+run_qa(type = "popgrp", filename = "work-life_balance", test_file = FALSE) # boring 
 
 #END
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -124,6 +124,9 @@ shes_from_ukds <- readRDS(file.path(profiles_data_folder, "Prepared Data", "shes
                               substr(code, 1, 3)=="S32" ~ "PD",
                               substr(code, 1, 3)=="S37" ~ "HSCP",
                               TRUE ~ "NA")) %>%
+  mutate(rate = round(rate,0),
+         lowci = round(lowci, 1),
+         upci = round(upci, 1)) %>%
   filter(!(split_name=="Deprivation (SIMD)" & areatype!="Scot" & sex!="Total")) # drop deprivation x sex for all lower geogs
 
 # Drop any geogs we don't want
@@ -370,7 +373,8 @@ source_comparison <- shes_from_dashboard %>%
   merge(y=shes_from_ukds, by=c("indicator", "ind_id", "code", "areatype", "year", "trend_axis", "def_period", "sex", "split_name", "split_value"), all=TRUE) %>%
   # keep only the geogs available in the dashboard (this drops any PD, HSCP or ADP data in the UKDS data)
   filter(areatype %in% c("Scot", "HB", "CA") & ind_id %in% inds_in_db) %>% 
-  mutate(on_dashboard = ifelse(is.na(source.x), "not on db", "on db"))
+  mutate(on_dashboard = ifelse(is.na(source.x), "not on db", "on db"),
+         rate_diff = round(rate.x-rate.y))
 
 # This comparison is limited to the indicators that are available from both sources:
 ftable(source_comparison$indicator, 
@@ -387,8 +391,16 @@ source_comparison %>%
   facet_wrap(~indicator)
 # SHOWS VERY CLOSE AND LARGELY PERFECT MATCH BETWEEN UKDS AND DASHBOARD DATA, WHERE BOTH ARE AVAILABLE. 
 # THE LINES ARE MOSTLY PERFECTLY STRAIGHT 1:1 RELATIONSHIPS, BUT SOME SLIGHT DISCREPANCIES APPARENT: 
-# main reason: UKDS estimates have more decimal places
-# also some of our indicators for children's PA exclude some ages in the original data (children participating in sport, )
+# some of our indicators for children's PA exclude some ages (2-4y) in the original data (children participating in sport, children very low activity) so the whole pop averages will be different
+table(source_comparison$indicator, source_comparison$rate_diff)
+# of 19,454 rates we can compare: 
+# 450 (2%) are from the 2 child PA indicators with different age groups, 
+table(source_comparison$indicator[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
+# of remaining 19,004
+# 18507 (97%) are identical
+# 466 (2% are 1%pt either side)
+# biggest diffs are 4%pts lower and higher: fruitveg consumption and problem drinker
+table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
 
 
 # Key points about the two sources:

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -400,7 +400,7 @@ table(source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)
 # 21539 (98%) are identical
 # 489 (2% are 1%pt either side)
 table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
-# bigger diffs go back to the years up to 2014 (fruit/veg consumption (30013) and problem drinking (4171))
+# bigger diffs (more than 1% point either side of the dashbaord figure) go back to the years up to 2014 (fruit/veg consumption (30013) and problem drinking (4171))
 # could suggest small differences in SHeS' processing back then?
 table(source_comparison$trend_axis[source_comparison$ind_id %in% c(30013, 4171)], source_comparison$rate_diff[source_comparison$ind_id %in% c(30013, 4171)])
 
@@ -662,7 +662,7 @@ run_qa(type = "main", filename = "children_very_low_activity", test_file = FALSE
 run_qa(type = "main", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "main", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "main", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-run_qa(type = "main", filename = "child_general_health", test_file = FALSE) 
+run_qa(type = "main", filename = "child_general_health", test_file = FALSE) # new source explains the differences (was HBSC previously)
 run_qa(type = "main", filename = "cyp_llti", test_file = FALSE) # new source explains the differences (was HBSC previously)
 
 # (b) smaller sample indicators (Scotland only)
@@ -696,11 +696,11 @@ run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file = FAL
 run_qa(type = "deprivation", filename = "unpaid_caring", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
 run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
-run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) 
-run_qa(type = "deprivation", filename = "food_insecurity", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) # CA and HSCP data removed as too many (>25%) with low sample sizes 
+run_qa(type = "deprivation", filename = "food_insecurity", test_file = FALSE) # CA and HSCP data removed as too many (>25%) with low sample sizes 
 run_qa(type = "deprivation", filename = "binge_drinking", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "problem_drinker", test_file = FALSE)  
-run_qa(type = "deprivation", filename = "mental_wellbeing", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "mental_wellbeing", test_file = FALSE) # CA and HSCP data removed as too many (>25%) with low sample sizes 
 run_qa(type = "deprivation", filename = "drinker_units", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "health_risk_behaviours", test_file = FALSE) # Scotland only because all data are from dashboard
 

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -396,13 +396,13 @@ table(source_comparison$indicator, source_comparison$rate_diff)
 # approx 2% of these comparisons are from the 2 child PA indicators with different age groups, 
 table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
 table(source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
-# of remaining 17,762
-# 17,299 (97%) are identical
-# 451 (3% are 1%pt either side)
-# biggest diffs are 4%pts lower and higher: fruitveg consumption (30013) and problem drinker (4171)
+# of remaining 22,040
+# 21539 (98%) are identical
+# 489 (2% are 1%pt either side)
 table(source_comparison$trend_axis[!source_comparison$ind_id %in% c(14006, 14003)], source_comparison$rate_diff[!source_comparison$ind_id %in% c(14006, 14003)])
+# bigger diffs go back to the years up to 2014 (fruit/veg consumption (30013) and problem drinking (4171))
+# could suggest small differences in SHeS' processing back then?
 table(source_comparison$trend_axis[source_comparison$ind_id %in% c(30013, 4171)], source_comparison$rate_diff[source_comparison$ind_id %in% c(30013, 4171)])
-# most concerned about problem drinkers in 2023: 1 at -2 and 7 at -1%pt. self-completion adjustment... try other weight instead?
 
 # Key points about the two sources:
 ## Aggregated UKDS data start from 2008-11, while the aggregated dashboard data starts at 2012-15. 
@@ -443,27 +443,11 @@ shes_combined <- shes_from_dashboard %>%
   mutate(rate = ifelse(ind_id==99121, rate.x, rate), 
          lowci = ifelse(ind_id==99121, lowci.x, lowci),
          upci = ifelse(ind_id==99121, upci.x, upci),
-         source = ifelse(ind_id==99121, source.x, source)) %>%
-  mutate(rate_diff = case_when(!is.na(rate.x) & !is.na(rate.y) ~ rate.x-rate.y, 
-                               TRUE ~ as.numeric(NA)),
-         rate_diff = round(sqrt(rate_diff*rate_diff))) # magnitude of the difference, to 0 dp
+         source = ifelse(ind_id==99121, source.x, source)) 
 #shes_from_dashboard has 25,693 records
-#shes_from_ukds has 499,383 records
-#shes_combined has 501,138 records
+#shes_from_ukds has 499,662 records
+#shes_combined has 501,417 records
 
-# check big diffs
-check <- shes_combined %>%
-  filter(rate_diff>0)
-ggplot(check) +
-  geom_point(aes(x=rate.x, y=rate.y)) +
-  facet_wrap(~indicator)
-check_all <- shes_combined %>%
-  filter(!is.na(rate_diff))
-
-
-table(check_all$indicator)
-table(check$indicator)
-table(check$indicator, check$split_name)
 
 ### 6. Check geographical availability: ----
 
@@ -640,11 +624,9 @@ prepare_final_files(ind = "healthy_weight")
 # Run QA reports 
 
 # NB differences from previous file identified for many, as now we're using the UKDS data where available for lower geogs, rather than dashboard. 
+# Also because we're no rounding to 0dp to match SHeS dashboard, so this looks like a 'difference' in the QA process
 # Did this so that all coincident geographies have the same data (otherwise Ed council and HSCP highlighted as having slight differences, when they should be identical).
 # I looked at the differences and many concerned the confidence intervals rather than the rates (SHeS must use a different type of survey estimation calculation). 
-# Rates were very similar, though the UKDS figures had 2 decimal places compared with 0 for SHeS dashboard, which sometimes showed as a big % difference if the rate was small.
-# Rates sometimes differ between UKDS and dashboard by around 1 % point.
-# Will add explanatory note to the techdoc.
 
 ###########################
 # Main data
@@ -660,7 +642,7 @@ run_qa(type = "main", filename = "fruit_veg_consumption", test_file = FALSE)
 run_qa(type = "main", filename = "unpaid_caring", test_file = FALSE)  
 run_qa(type = "main", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
 run_qa(type = "main", filename = "adults_very_low_activity", test_file = FALSE)
-run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) # lower geogs only have data up to 2016-19 (same as existing ScotPHO data) NEEDS TO BE FIXED: WAITING FOR SHES COMMENT
+run_qa(type = "main", filename = "healthy_weight", test_file = FALSE) 
 run_qa(type = "main", filename = "food_insecurity", test_file = FALSE) 
 run_qa(type = "main", filename = "binge_drinking", test_file = FALSE)  
 run_qa(type = "main", filename = "problem_drinker", test_file = FALSE)  
@@ -703,6 +685,8 @@ run_qa(type = "main", filename = "work-life_balance", test_file = FALSE)
 # some gaps at lower geogs 
 
 # (a) main sample indicators (Scot + lower geogs) (lower geogs will only have sex==Total)
+# NB. latest = 2024 for Scotland, but 2021-24 (shown in QA shiny plot as year==2023) for lower geogs
+# some lower geogs are missing (geog tallies show red in QA) as values could only be produced for fewer than 3 quintiles (island boards kept if they have values for 3 or 4 quintiles)
 run_qa(type = "deprivation", filename = "common_mh_probs", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "self_assessed_health", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "life_satisfaction", test_file = FALSE)   
@@ -712,13 +696,14 @@ run_qa(type = "deprivation", filename = "fruit_veg_consumption", test_file = FAL
 run_qa(type = "deprivation", filename = "unpaid_caring", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "meeting_muscle_strengthening_recommendations", test_file = FALSE)
 run_qa(type = "deprivation", filename = "adults_very_low_activity", test_file = FALSE)
-run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) # lower geogs only have data up to 2016-19 (same as existing ScotPHO data) NEEDS TO BE FIXED: WAITING FOR SHES COMMENT
+run_qa(type = "deprivation", filename = "healthy_weight", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "food_insecurity", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "binge_drinking", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "problem_drinker", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "mental_wellbeing", test_file = FALSE) 
 run_qa(type = "deprivation", filename = "drinker_units", test_file = FALSE)  
 run_qa(type = "deprivation", filename = "health_risk_behaviours", test_file = FALSE) # Scotland only because all data are from dashboard
+
 # (ai) main children indicators: Scot only
 run_qa(type = "deprivation", filename = "cyp_parent_w_ghq4", test_file = FALSE)     
 run_qa(type = "deprivation", filename = "cyp_parent_w_harmful_alc", test_file = FALSE) 
@@ -745,7 +730,7 @@ run_qa(type = "deprivation", filename = "line_manager", test_file = FALSE)
 run_qa(type = "deprivation", filename = "depression_symptoms", test_file = FALSE)   
 run_qa(type = "deprivation", filename = "anxiety_symptoms", test_file = FALSE)   
 run_qa(type = "deprivation", filename = "deliberate_selfharm", test_file = FALSE)    
-run_qa(type = "deprivation", filename = "attempted_suicide", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "attempted_suicide", test_file = FALSE) #drop ineqs and other splits now
 run_qa(type = "deprivation", filename = "work-life_balance", test_file = FALSE) 
 
 ###########################

--- a/Scottish Health Survey.R
+++ b/Scottish Health Survey.R
@@ -718,8 +718,8 @@ run_qa(type = "deprivation", filename = "children_very_low_activity", test_file 
 run_qa(type = "deprivation", filename = "children_participating_sport", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_active_play", test_file = FALSE)
 run_qa(type = "deprivation", filename = "children_meet_pa_recs_excl_school", test_file = FALSE)
-run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE) # Scot + Police Depts (WHY?)
-run_qa(type = "deprivation", filename = "cyp_llti", test_file = FALSE) # Scot + Police Depts (WHY?)
+run_qa(type = "deprivation", filename = "child_general_health", test_file = FALSE) 
+run_qa(type = "deprivation", filename = "cyp_llti", test_file = FALSE) 
 
 # (b) smaller sample indicators (Scotland only)
 run_qa(type = "deprivation", filename = "involved_locally", test_file = FALSE)   


### PR DESCRIPTION
Having reviewed script by @abigap01 for extracting PA indicator data from SHeS microdata (in the ScotPHO_survey_data repo) we thought it made sense to do the extraction and initial processing for all the indicators in one place there... and then process in the Scottish Health Survey.R script in this repo. So am adding you both to review these amendments. 

NB. Code to produce the PA indicators has been commented out at this stage, ready to be run when you want, Abbie. 

I thought the additional splits you're using made sense @abigap01 (long-term illness, and coarse age groups) so I'm using them for the other indicators from SHeS too. NB @vaelliott: this includes some Care and Wellbeing indicators, and some Alcohol profile indicators. Suppression has been used if denominators are <30, as required by SHeS, and splits aren't presented for lower geographies if their are a lot of suppressed cells. 

Some quirks to note.
1. In this script I add in the published SHeS data downloaded from statistics.gov.scot. This includes data for 6 mental health indicators. It also includes your muscle/strength recommendations indicator Abbie, so it might be worth looking at what is available in the download and seeing how you want to use that data. I treat the statistics.gov.scot data as definitive, so use it when available, and supplement with any additional splits I have produced. 
2. 'Long-term illnesses' and 'long-term conditions' seem to be used interchangeably in SHeS reporting, and the questionnaire and data dictionaries suggest they are referring to the same thing. I've gone with long term illness for the final indicators (as is the terminology in the UKDS data). 

The QAs look OK. I'll transfer the non-PA profile files to the folder ready for deployment. 