### PR TITLE
Ns drugalc treatment waiting times

### DIFF
--- a/3.Data Quality Checks.Rmd
+++ b/3.Data Quality Checks.Rmd
@@ -74,7 +74,7 @@ data_indicator$upci[is.na(data_indicator$upci)] <- 0 # Converting NA's to 0s
 old_file <-ifelse((!is.null(old_filename)),old_filename,filename)
 
 # Create object detailing filepath of comparison file (this appears in checking report)
-old_indicator_filepath <- paste0(profiles_data_folder, "Shiny Data/", old_file, "_shiny.rds")
+old_indicator_filepath <- paste0(profiles_data_folder, "/Shiny Data/", old_file, "_shiny.rds")
 
 
 # statement that checks if there an old indicator data file of the same name exists in Shiny data folder 

--- a/Alcohol treatment waiting times.R
+++ b/Alcohol treatment waiting times.R
@@ -67,8 +67,22 @@ alcohol_wt <- alcohol_wt |>
 # Save alcohol treatment waiting times basefile to 'Prepared Data' folder (to be fed into main_analysis() function).
 saveRDS(alcohol_wt, file=paste0(profiles_data_folder, '/Prepared Data/Alcohol_waiting_times_raw.rds'))
 
-awt_raw <- readRDS(paste0(profiles_data_folder, "/Prepared Data/Alcohol_waiting_times_raw.rds"))
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 2 - Run alcohol treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+# Call main_analysis() function for alcohol treatment waiting times calculating percentage referrals waiting more than 3 weeks for treatment
+# and saving output to the 'Data to be checked' folder.
+main_analysis(filename = "Alcohol_waiting_times",
+              measure = "percent",
+              geography = "multiple",
+              time_agg = 1,
+              year_type = "financial",
+              yearstart = 2015,
+              yearend = 2024,
+              ind_id = 4119,
+              test_file = FALSE,
+              QA = TRUE)
 
 
 # Last update first basefile passed into analyze_second() - doesn't go through analyze_first() - saved to Temporary (10/11/2023 13:05)
@@ -82,13 +96,6 @@ awt_raw <- readRDS(paste0(profiles_data_folder, "/Prepared Data/Alcohol_waiting_
 
 # An old basefile from a previous update (2019) saved to Prepared Data
 # awt_prepareddata_old <- readRDS(paste0(profiles_data_folder, "/Prepared Data/Alcohol_waiting_times_raw.rds")) # Saved 04/11/2019 13:06
-
-
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-# PART 2 - Run alcohol treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder ----
-# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Alcohol treatment waiting times.R
+++ b/Alcohol treatment waiting times.R
@@ -64,11 +64,25 @@ alcohol_wt <- alcohol_wt |>
             denominator = sum(denominator)) |> 
   ungroup()
 
-# Save basefile to 'Prepared Data' folder to be fed into main_analysis() function
-saveRDS(alcohol_wt, file=paste0(profiles_data_folder, '/Prepared Data/alcohol_waiting_times_raw.rds'))
+# Save alcohol treatment waiting times basefile to 'Prepared Data' folder (to be fed into main_analysis() function).
+saveRDS(alcohol_wt, file=paste0(profiles_data_folder, '/Prepared Data/Alcohol_waiting_times_raw.rds'))
 
-# This will save a file with variables year/geography/code/numerator/denominator - Is this correct?
-# Name of file - how do we know what the filename should be?
+awt_raw <- readRDS(paste0(profiles_data_folder, "/Prepared Data/Alcohol_waiting_times_raw.rds"))
+
+
+
+# Last update first basefile passed into analyze_second() - doesn't go through analyze_first() - saved to Temporary (10/11/2023 13:05)
+# awt_basefile_old <- readRDS(paste0(profiles_data_folder, "/Temporary/Alcohol_waiting_times_formatted.rds"))
+
+# Last update output file from running _formatted.rds through analyze_second() and saved to Temporary (17/11/2023 14:21)
+# awt_basefilefinal_old <- readRDS(paste0(profiles_data_folder, "/Temporary/Alcohol_waiting_times_final.rds")) 
+
+# Last update final output file for profiles tool, as _final.rds above but minus geography and denominator variables saved to Shiny Data (17/11/2023 14:21)
+# awt_finaloutputfile_old <- readRDS(paste0(profiles_data_folder, "/Shiny Data/Alcohol_waiting_times_shiny.rds"))
+
+# An old basefile from a previous update (2019) saved to Prepared Data
+# awt_prepareddata_old <- readRDS(paste0(profiles_data_folder, "/Prepared Data/Alcohol_waiting_times_raw.rds")) # Saved 04/11/2019 13:06
+
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 # PART 2 - Run alcohol treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder ----

--- a/Alcohol treatment waiting times.R
+++ b/Alcohol treatment waiting times.R
@@ -24,7 +24,57 @@ source("functions/main_analysis.R") # Brings in the main_analysis() function
 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 # Read in alcohol treatment waiting times data file supplied by PHS Drugs Team.
-alcohol_wt <- read_csv(paste0(profiles_data_folder, "/Received Data/Drug and alcohol treatment waiting times/2025 request/alcohol_waiting_times_2024-25.csv"))
+alcohol_wt <- read_csv(paste0(profiles_data_folder, "/Received Data/Drug and alcohol treatment waiting times/2025 request/alcohol_waiting_times_2024-25.csv")) |>
+  clean_names() |> # Variable names to lower case
+  mutate(code = case_when( # Create a variable called code to record the code that matches the ADP/HB name in the geography variable
+    geography == "Clackmannanshire_ADP" ~ "S11000005", geography == "Falkirk_ADP" ~ "S11000013", 
+    geography == "Stirling_ADP" ~ "S11000029", geography == "East Ayrshire_ADP" ~ "S11000008", 
+    geography == "North Ayrshire_ADP" ~ "S11000020", geography == "South Ayrshire_ADP" ~ "S11000027", 
+    geography == "Mid and East Lothian_ADP" ~ "S11000051", geography == "West Lothian_ADP" ~ "S11000031", 
+    geography == "City of Edinburgh_ADP" ~ "S11000012", geography == "East Renfrewshire_ADP" ~ "S11000011", 
+    geography == "East Dunbartonshire_ADP" ~ "S11000009", geography == "Inverclyde_ADP" ~ "S11000017", 
+    geography == "Renfrewshire_ADP" ~ "S11000024", geography == "West Dunbartonshire_ADP" ~ "S11000030", 
+    geography == "City of Glasgow_ADP" ~ "S11000015", geography == "Highland_ADP" ~ "S11000016", 
+    geography == "Argyll & Bute_ADP" ~ "S11000004", geography == "Moray_ADP" ~ "S11000019", 
+    geography == "Aberdeen City_ADP" ~ "S11000001", geography == "Aberdeenshire_ADP" ~ "S11000002", 
+    geography == "Perth & Kinross_ADP" ~ "S11000023", geography == "Angus_ADP" ~ "S11000003", 
+    geography == "Dundee City_ADP" ~ "S11000007", geography == "Dumfries & Galloway_ADP" ~ "S11000006", 
+    geography == "Fife_ADP" ~ "S11000014", geography == "Orkney Islands_ADP" ~ "S11000022", 
+    geography == "Scottish Borders_ADP" ~ "S11000025", geography == "Shetland Islands_ADP" ~ "S11000026", 
+    geography == "Western Isles_ADP" ~ "S11000032", geography == "Ayrshire & Arran_HB" ~ "S08000015", 
+    geography == "Borders_HB" ~ "S08000016", geography == "Dumfries & Galloway_HB" ~ "S08000017", 
+    geography == "Fife_HB" ~ "S08000029", geography == "Forth Valley_HB" ~ "S08000019",
+    geography == "Grampian_HB" ~ "S08000020", geography == "Greater Glasgow & Clyde_HB" ~ "S08000031", 
+    geography == "Highland_HB" ~ "S08000022", geography == "Lanarkshire_HB" ~ "S08000032", 
+    geography == "Lothian_HB" ~ "S08000024", geography == "Orkney_HB" ~ "S08000025", 
+    geography == "Shetland_HB" ~ "S08000026", geography == "Tayside_HB" ~ "S08000030", 
+    geography == "Western Isles_HB" ~ "S08000028", 
+    geography == "Scotland" ~ "S00000001", TRUE ~ "Error")) |>
+  mutate(year = as.numeric(substr(financial_year,1,4))) # Create variable called year to record financial year in format required by main_analysis() function
+
+# North and South Lanarkshire ADPs are combined as Lanarkshire ADP for the purposes of the Profiles tool
+alcohol_wt <- alcohol_wt |>
+  mutate(code = case_when(geography == "South Lanarkshire_ADP" ~ "S11000052",
+                          geography == "North Lanarkshire_ADP" ~ "S11000052",
+                          TRUE ~ as.character(code))) |> 
+  mutate(geography = case_when(code == "S11000052" ~ "Lanarkshire_ADP",
+                               TRUE ~ as.character(geography))) |> 
+  group_by(year, geography, code) |> 
+  summarise(numerator = sum(numerator),
+            denominator = sum(denominator)) |> 
+  ungroup()
+
+# Save basefile to 'Prepared Data' folder to be fed into main_analysis() function
+saveRDS(alcohol_wt, file=paste0(profiles_data_folder, '/Prepared Data/alcohol_waiting_times_raw.rds'))
+
+# This will save a file with variables year/geography/code/numerator/denominator - Is this correct?
+# Name of file - how do we know what the filename should be?
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 2 - Run alcohol treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+
 
 
 # ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/Alcohol treatment waiting times.R
+++ b/Alcohol treatment waiting times.R
@@ -1,3 +1,36 @@
+# ~~~~~~~~~~~~~~~~~~~~~~~
+# ---- Analyst Notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~
+
+# Indicator: Alcohol treatment waiting times - % where LDP Standard (90%) not met (id = 4119)
+
+# Description: The LDP Standard is that 90% of people referred for help with problematic drug or alcohol use will wait no longer than
+# three weeks for specialist treatment that supports their recovery.
+
+# Data source: Drug and Alcohol Information System (DAISy) and its predecessor the Drug and Alcohol Treatment Waiting Times (DATWT) database.
+# The drug, alcohol and co-dependency treatment waiting times data files are supplied by the PHS Drugs Team (phs.drugsteam@phs.scot).
+
+# PART 1 - Read in received data, format data and create basefile for main_analysis() function
+# PART 2 - Run alcohol treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Libraries, functions and filepaths ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+source("functions/main_analysis.R") # Brings in the main_analysis() function
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 1 - Read in received data, format data and create basefile for main_analysis() function ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Read in alcohol treatment waiting times data file supplied by PHS Drugs Team.
+alcohol_wt <- read_csv(paste0(profiles_data_folder, "/Received Data/Drug and alcohol treatment waiting times/2025 request/alcohol_waiting_times_2024-25.csv"))
+
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+
+# OLD CODE
+
 # ScotPHO indicators: Alcohol treatment waiting times - % where LDP Standard (90%) not met
 
 #   Part 1 - Create basefile

--- a/Alcohol treatment waiting times.R
+++ b/Alcohol treatment waiting times.R
@@ -82,7 +82,9 @@ main_analysis(filename = "Alcohol_waiting_times",
               yearend = 2024,
               ind_id = 4119,
               test_file = FALSE,
-              QA = TRUE)
+              QA = FALSE)
+
+run_qa(filename = "Alcohol_waiting_times", type = "main")
 
 
 # Last update first basefile passed into analyze_second() - doesn't go through analyze_first() - saved to Temporary (10/11/2023 13:05)

--- a/Drug and alcohol co-dependency treatment waiting times.R
+++ b/Drug and alcohol co-dependency treatment waiting times.R
@@ -1,22 +1,33 @@
-# ScotPHO indicator: Drug and alcohol co-dependency treatment waiting times - % where LDP Standard (90%) not met
-# New indicator added in October 2022
+# ~~~~~~~~~~~~~~~~~~~~~~~
+# ---- Analyst Notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~
 
-#   Part 1 - Create basefile
-#   Part 2 - Format  Basefile for macro
-#   Part 3 - Call analysis macros
+# Indicator: Drug and alcohol co-dependency treatment waiting times - % where LDP Standard (90%) not met (id = 4150)
 
-###############################################.
-## Packages/Filepaths/Functions ----
-###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
+# Description: The LDP Standard is that 90% of people referred for help with problematic drug or alcohol use will wait no longer than
+# three weeks for specialist treatment that supports their recovery.
 
-###############################################.
-## Part 1 - Create basefile ----
-###############################################.
-#Reading data provided by DWT team
-cwt <- read_csv(paste0(data_folder, "Received Data//Drug and alcohol treatment waiting times/2023 request/co-dependency_waiting_times.csv")) %>% 
-  setNames(tolower(names(.))) %>%   #variables to lower case
-  mutate(code = case_when( #create a code variable for each ADP and HB
+# Data source: Drug and Alcohol Information System (DAISy) and its predecessor the Drug and Alcohol Treatment Waiting Times (DATWT) database.
+# The drug, alcohol and co-dependency treatment waiting times data files are supplied by the PHS Drugs Team (phs.drugsteam@phs.scot).
+
+# PART 1 - Read in received data, format data and create basefile for main_analysis() function
+# PART 2 - Run drug and alcohol co-dependency treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Libraries, functions and filepaths ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+source("functions/main_analysis.R") # Brings in the main_analysis() function
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 1 - Read in received data, format data and create basefile for main_analysis() function ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Read in drug and alcohol co-dependency treatment waiting times data file supplied by PHS Drugs Team.
+codependency_wt <- read_csv(paste0(profiles_data_folder, 
+                                   "/Received Data/Drug and alcohol treatment waiting times/2025 request/drugalc_co-dependency_waiting_times_2024-25.csv")) |>
+  clean_names() |> # Variable names to lower case
+  mutate(code = case_when( # Create a variable called code to record the code that matches the ADP/HB name in the geography variable
     geography == "Clackmannanshire_ADP" ~ "S11000005", geography == "Falkirk_ADP" ~ "S11000013", 
     geography == "Stirling_ADP" ~ "S11000029", geography == "East Ayrshire_ADP" ~ "S11000008", 
     geography == "North Ayrshire_ADP" ~ "S11000020", geography == "South Ayrshire_ADP" ~ "S11000027", 
@@ -39,30 +50,41 @@ cwt <- read_csv(paste0(data_folder, "Received Data//Drug and alcohol treatment w
     geography == "Lothian_HB" ~ "S08000024", geography == "Orkney_HB" ~ "S08000025", 
     geography == "Shetland_HB" ~ "S08000026", geography == "Tayside_HB" ~ "S08000030", 
     geography == "Western Isles_HB" ~ "S08000028", 
-    geography == "Scotland" ~ "S00000001", TRUE ~ "Error")) %>% 
-  mutate(year = as.numeric(substr(financial_year,1,4)))   #converting to numeric as needed for functions 
+    geography == "Scotland" ~ "S00000001", TRUE ~ "Error")) |>
+  mutate(year = as.numeric(substr(financial_year,1,4))) # Create variable called year to record financial year in format required by main_analysis() function
 
-
-# ADPs for North and South Lanarkshire need to be combined as they are still combined as Lanarkshire in Profiles lookups
-cwt <- cwt %>%
+# North and South Lanarkshire ADPs are combined as Lanarkshire ADP for the purposes of the Profiles tool
+codependency_wt <- codependency_wt |>
   mutate(code = case_when(geography == "South Lanarkshire_ADP" ~ "S11000052",
                           geography == "North Lanarkshire_ADP" ~ "S11000052",
-                          TRUE ~ as.character(code))) %>% 
+                          TRUE ~ as.character(code))) |> 
   mutate(geography = case_when(code == "S11000052" ~ "Lanarkshire_ADP",
-                               TRUE ~ as.character(geography))) %>% 
-  group_by(year, geography, code) %>% 
+                               TRUE ~ as.character(geography))) |> 
+  group_by(year, geography, code) |> 
   summarise(numerator = sum(numerator),
-            denominator = sum(denominator)) %>% 
+            denominator = sum(denominator)) |> 
   ungroup()
 
+# Save drug and alcohol co-dependency treatment waiting times basefile to 'Prepared Data' folder (to be fed into main_analysis() function).
+saveRDS(codependency_wt, file=paste0(profiles_data_folder, '/Prepared Data/Co-dependency_waiting_times_raw.rds'))
 
-saveRDS(cwt, file=paste0(data_folder, 'Temporary/Co-dependency_waiting_times_formatted.rds'))
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 2 - Run drug and alcohol co-dependency treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-###############################################.
-## Part 2 - Call analysis macros ----
-###############################################.
-analyze_second(filename = "Co-dependency_waiting_times", measure = "percent", 
-               time_agg = 1, ind_id = 4150, year_type = "financial")
+# Call main_analysis() function for drug and alcohol co-dependency treatment waiting times calculating percentage referrals waiting more than 3 weeks for
+# treatment and saving output to the 'Data to be checked' folder.
+main_analysis(filename = "Co-dependency_waiting_times",
+              measure = "percent",
+              geography = "multiple",
+              time_agg = 1,
+              year_type = "financial",
+              yearstart = 2020,
+              yearend = 2024,
+              ind_id = 4150,
+              test_file = FALSE,
+              QA = FALSE)
 
+run_qa(filename = "Co-dependency_waiting_times", type = "main")
 
-##END
+# END

--- a/Drug treatment waiting times.R
+++ b/Drug treatment waiting times.R
@@ -1,21 +1,32 @@
-# ScotPHO indicators: Drug Waiting Times
+# ~~~~~~~~~~~~~~~~~~~~~~~
+# ---- Analyst Notes ----
+# ~~~~~~~~~~~~~~~~~~~~~~~
 
-#   Part 1 - Create basefile
-#   Part 2 - Format  Basefile for macro
-#   Part 3 - Call analysis macros
+# Indicator: Drug treatment waiting times - % where LDP Standard (90%) not met (id = 4136)
 
-###############################################.
-## Packages/Filepaths/Functions ----
-###############################################.
-source("1.indicator_analysis.R") #Normal indicator functions
+# Description: The LDP Standard is that 90% of people referred for help with problematic drug or alcohol use will wait no longer than
+# three weeks for specialist treatment that supports their recovery.
 
-###############################################.
-## Part 1 - Create basefile ----
-###############################################.
-#Reading data provided by DWT team
-dwt <- read_csv(paste0(data_folder, "Received Data/Drug and alcohol treatment waiting times/2023 request/drug_waiting_times.csv")) %>% 
-  setNames(tolower(names(.))) %>%   #variables to lower case
-  mutate(code = case_when( #create a code variable for each ADP and HB
+# Data source: Drug and Alcohol Information System (DAISy) and its predecessor the Drug and Alcohol Treatment Waiting Times (DATWT) database.
+# The drug, alcohol and co-dependency treatment waiting times data files are supplied by the PHS Drugs Team (phs.drugsteam@phs.scot).
+
+# PART 1 - Read in received data, format data and create basefile for main_analysis() function
+# PART 2 - Run drug treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# Libraries, functions and filepaths ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+source("functions/main_analysis.R") # Brings in the main_analysis() function
+
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 1 - Read in received data, format data and create basefile for main_analysis() function ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+# Read in drug treatment waiting times data file supplied by PHS Drugs Team.
+drug_wt <- read_csv(paste0(profiles_data_folder, "/Received Data/Drug and alcohol treatment waiting times/2025 request/drug_waiting_times_2024-25.csv")) |>
+  clean_names() |> # Variable names to lower case
+  mutate(code = case_when( # Create a variable called code to record the code that matches the ADP/HB name in the geography variable
     geography == "Clackmannanshire_ADP" ~ "S11000005", geography == "Falkirk_ADP" ~ "S11000013", 
     geography == "Stirling_ADP" ~ "S11000029", geography == "East Ayrshire_ADP" ~ "S11000008", 
     geography == "North Ayrshire_ADP" ~ "S11000020", geography == "South Ayrshire_ADP" ~ "S11000027", 
@@ -38,30 +49,41 @@ dwt <- read_csv(paste0(data_folder, "Received Data/Drug and alcohol treatment wa
     geography == "Lothian_HB" ~ "S08000024", geography == "Orkney_HB" ~ "S08000025", 
     geography == "Shetland_HB" ~ "S08000026", geography == "Tayside_HB" ~ "S08000030", 
     geography == "Western Isles_HB" ~ "S08000028", 
-    geography == "Scotland" ~ "S00000001", TRUE ~ "Error")) %>% 
-  mutate(year = as.numeric(substr(financial_year,1,4)))   #converting to numeric as needed for functions 
+    geography == "Scotland" ~ "S00000001", TRUE ~ "Error")) |>
+  mutate(year = as.numeric(substr(financial_year,1,4))) # Create variable called year to record financial year in format required by main_analysis() function
 
-
-# ADPs for North and South Lanarkshire need to be combined as they are still combined as Lanarkshire in Profiles lookups
-dwt <- dwt %>%
+# North and South Lanarkshire ADPs are combined as Lanarkshire ADP for the purposes of the Profiles tool
+drug_wt <- drug_wt |>
   mutate(code = case_when(geography == "South Lanarkshire_ADP" ~ "S11000052",
                           geography == "North Lanarkshire_ADP" ~ "S11000052",
-                          TRUE ~ as.character(code))) %>% 
+                          TRUE ~ as.character(code))) |> 
   mutate(geography = case_when(code == "S11000052" ~ "Lanarkshire_ADP",
-                               TRUE ~ as.character(geography))) %>% 
-  group_by(year, geography, code) %>% 
+                               TRUE ~ as.character(geography))) |> 
+  group_by(year, geography, code) |> 
   summarise(numerator = sum(numerator),
-            denominator = sum(denominator)) %>% 
+            denominator = sum(denominator)) |> 
   ungroup()
 
-  
-saveRDS(dwt, file=paste0(data_folder, 'Temporary/Drug_waiting_times_formatted.rds'))
+# Save drug treatment waiting times basefile to 'Prepared Data' folder (to be fed into main_analysis() function).
+saveRDS(drug_wt, file=paste0(profiles_data_folder, '/Prepared Data/Drug_waiting_times_raw.rds'))
 
-###############################################.
-## Part 2 - Call analysis macros ----
-###############################################.
-analyze_second(filename = "Drug_waiting_times", measure = "percent", 
-               time_agg = 1, ind_id = 4136, year_type = "financial")
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+# PART 2 - Run drug treatment waiting times basefile through main_analysis() function and save output to 'Data to be checked' folder ----
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
+# Call main_analysis() function for drug treatment waiting times calculating percentage referrals waiting more than 3 weeks for treatment
+# and saving output to the 'Data to be checked' folder.
+main_analysis(filename = "Drug_waiting_times",
+              measure = "percent",
+              geography = "multiple",
+              time_agg = 1,
+              year_type = "financial",
+              yearstart = 2015,
+              yearend = 2024,
+              ind_id = 4136,
+              test_file = FALSE,
+              QA = FALSE)
 
-##END
+run_qa(filename = "Drug_waiting_times", type = "main")
+
+# END


### PR DESCRIPTION
Updating drug, alcohol and co-dependency treatment waiting times indicators (x3) with 2023/24 and 2024/25 data. Data files supplied by drugs team for this update provides data from 2015/16 (previous data from 2012/13), so this update only includes data from 2015/16 onwards.

QA script, data check 3 highlights geographies where values in latest indicator file differ by >5% from previous figs. I've checked a sample of highlighted geographies and confirmed that these reflect changes in the underlying data supplied by the drugs team.

Co-dependency indicator, data check 7 highlights a lot of geographies with numerators <5. Is this likely to be an issue with publishing the data?